### PR TITLE
Only retrieve details for tables and not views

### DIFF
--- a/src/Meta/MySql/Schema.php
+++ b/src/Meta/MySql/Schema.php
@@ -79,7 +79,7 @@ class Schema implements \Reliese\Meta\Schema
     protected function fetchTables($schema)
     {
         $rows = $this->connection->select('SHOW FULL TABLES FROM '.$schema.' WHERE Table_type=\'BASE TABLE\'');
-        $names = array_column($rows, 'Tables_in_' . $schema);
+        $names = array_column($rows, 'Tables_in_'.$schema);
         $tables = Arr::flatten($names);
 
         return array_diff($tables, [

--- a/src/Meta/MySql/Schema.php
+++ b/src/Meta/MySql/Schema.php
@@ -78,8 +78,9 @@ class Schema implements \Reliese\Meta\Schema
      */
     protected function fetchTables($schema)
     {
-        $rows = $this->connection->select('SHOW TABLES FROM '.$schema);
-        $tables = Arr::flatten($rows);
+        $rows = $this->connection->select('SHOW FULL TABLES FROM '.$schema.' WHERE Table_type=\'BASE TABLE\'');
+        $names = array_column($rows, 'Tables_in_' . $schema);
+        $tables = Arr::flatten($names);
 
         return array_diff($tables, [
             'migrations',


### PR DESCRIPTION
Generation crashes when a view is retrieved from the database.