### PR TITLE
Option to generate relation names using foreign keys

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -320,14 +320,15 @@ return [
         |               (post.author --> user.id)
                             generates Post::user() and User::posts()
         |
-        | 'foreign_key' Use the foreign key as the relation name. If the foreign
-        |               contains the other key as a suffix, it is removed.
-        |               (post.author --> user.id)
-        |                   generates Post::author() and User::posts_author()
-        |               (post.author_id --> user.id)
-        |                   generates Post::author() and User::posts_author()
-        |               (post.user_id --> user.id)
-        |                   generates Post::user() and User::posts()
+        | 'foreign_key' Use the foreign key as the relation name.
+        |                   (post.author --> user.id)
+        |                       generates Post::author() and User::posts_author()
+        |               Column id's are ignored.
+        |                   (post.author_id --> user.id)
+        |                       generates the same as above.
+        |               When the foreign key is redundant, it is omited.
+        |                   (post.user_id --> user.id)
+        |                       generates User::posts() and not User::posts_user()
         */
 
         'relation_name_strategy' => 'related',

--- a/config/models.php
+++ b/config/models.php
@@ -308,6 +308,26 @@ return [
         */
 
         'table_prefix' => '',
+
+        /*
+        |--------------------------------------------------------------------------
+        | Relation Name Strategy
+        |--------------------------------------------------------------------------
+        |
+        | How the relations should be named in your models.
+        |
+        | 'related'     Use the related table as the relation name.
+        |               (post.author -> user.id) will be called 'user'
+        |
+        | 'foreign_key' Use the foreign key as the relation name. If the foreign
+        |               contains the other key as a suffix, it is removed.
+        |               (post.author -> user.id) will be called 'author'
+        |               (user.author_id -> user.id) will be called 'author'
+        |               (user.country_code -> country.code) will be called 'country'
+        */
+
+        'relation_name_strategy' => 'related',
+        // 'relation_name_strategy' => 'foreign_key',
     ],
 
     /*

--- a/config/models.php
+++ b/config/models.php
@@ -317,13 +317,17 @@ return [
         | How the relations should be named in your models.
         |
         | 'related'     Use the related table as the relation name.
-        |               (post.author -> user.id) will be called 'user'
+        |               (post.author --> user.id)
+                            generates Post::user() and User::posts()
         |
         | 'foreign_key' Use the foreign key as the relation name. If the foreign
         |               contains the other key as a suffix, it is removed.
-        |               (post.author -> user.id) will be called 'author'
-        |               (user.author_id -> user.id) will be called 'author'
-        |               (user.country_code -> country.code) will be called 'country'
+        |               (post.author --> user.id)
+        |                   generates Post::author() and User::posts_author()
+        |               (post.author_id --> user.id)
+        |                   generates Post::author() and User::posts_author()
+        |               (post.user_id --> user.id)
+        |                   generates Post::user() and User::posts()
         */
 
         'relation_name_strategy' => 'related',

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -158,6 +158,12 @@ class Model
     protected $tablePrefix = '';
 
     /**
+     * @var string
+     */
+    protected $relationNameStrategy = '';
+
+
+    /**
      * ModelClass constructor.
      *
      * @param \Reliese\Meta\Blueprint $blueprint
@@ -201,6 +207,9 @@ class Model
 
         // Table Prefix settings
         $this->withTablePrefix($this->config('table_prefix', $this->getDefaultTablePrefix()));
+
+        // Relation name settings
+        $this->withRelationNameStrategy($this->config('relation_name_strategy', $this->getDefaultRelationNameStrategy()));
 
         return $this;
     }
@@ -419,6 +428,14 @@ class Model
     public function getNamespace()
     {
         return $this->namespace;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRelationNameStrategy()
+    {
+        return $this->relationNameStrategy;
     }
 
     /**
@@ -673,6 +690,14 @@ class Model
     }
 
     /**
+     * @param string $relationNameStrategy
+     */
+    public function withRelationNameStrategy($relationNameStrategy)
+    {
+        $this->relationNameStrategy = $relationNameStrategy;
+    }
+
+    /**
      * @param string $table
      */
     public function removeTablePrefix($table)
@@ -866,6 +891,14 @@ class Model
     public function getDefaultTablePrefix()
     {
         return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultRelationNameStrategy()
+    {
+        return 'related';
     }
 
     /**

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -162,7 +162,6 @@ class Model
      */
     protected $relationNameStrategy = '';
 
-
     /**
      * ModelClass constructor.
      *

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -49,11 +49,21 @@ class BelongsTo implements Relation
      */
     public function name()
     {
-        if ($this->parent->usesSnakeAttributes()) {
-            return Str::snake($this->related->getClassName());
+        switch ($this->parent->getRelationNameStrategy()) {
+            case 'foreign_key':
+                $relationName = preg_replace("/[^a-zA-Z0-9]?{$this->otherKey()}$/", '', $this->foreignKey());
+                break;
+            default:
+            case 'related':
+                $relationName = $this->related->getClassName();
+                break;
         }
 
-        return Str::camel($this->related->getClassName());
+        if ($this->parent->usesSnakeAttributes()) {
+            return Str::snake($relationName);
+        }
+
+        return Str::camel($relationName);
     }
 
     /**

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -25,11 +25,31 @@ class HasMany extends HasOneOrMany
      */
     public function name()
     {
-        if ($this->parent->usesSnakeAttributes()) {
-            return Str::snake(Str::plural(Str::singular($this->related->getTable(true))));
+        $relationBaseName = Str::plural(Str::singular($this->related->getTable(true)));
+
+        switch ($this->parent->getRelationNameStrategy()) {
+            case 'foreign_key':
+                $suffix = preg_replace("/[^a-zA-Z0-9]?{$this->localKey()}$/", '', $this->foreignKey());
+
+                $relationName = $relationBaseName;
+
+                // Don't make relations such as users_user, just leave it as 'users'.
+                if ($this->parent->getTable(true) !== $suffix) {
+                    $relationName .= "_{$suffix}";
+                }
+
+                break;
+            case 'related':
+            default:
+                $relationName = $relationBaseName;
+                break;
         }
 
-        return Str::camel(Str::plural(Str::singular($this->related->getTable(true))));
+        if ($this->parent->usesSnakeAttributes()) {
+            return Str::snake($relationName);
+        }
+
+        return Str::camel($relationName);
     }
 
     /**

--- a/src/Meta/Blueprint.php
+++ b/src/Meta/Blueprint.php
@@ -52,17 +52,23 @@ class Blueprint
     protected $primaryKey;
 
     /**
+     * @var bool
+     */
+    protected $isView;
+
+    /**
      * Blueprint constructor.
      *
      * @param string $connection
      * @param string $schema
      * @param string $table
      */
-    public function __construct($connection, $schema, $table)
+    public function __construct($connection, $schema, $table, $isView = false)
     {
         $this->connection = $connection;
         $this->schema = $schema;
         $this->table = $table;
+        $this->isView = $isView;
     }
 
     /**
@@ -271,5 +277,13 @@ class Blueprint
         }
 
         return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isView()
+    {
+        return $this->isView;
     }
 }


### PR DESCRIPTION
I had a database model like this:

    post.author_user_id --> user.id
    post.deleted_by_user_id --> user.id
   
Which only generated methods for the last relation (because of the same table)

    Post::user() + User::posts()

I wanted it to generate

    Post::authorUser() + User::postsAuthorUser()
    Post::deletedByUser() + User::postsDeletedByUser()

This pull request makes that possible by adding a configuration key `relation_name_strategy`. The default is `related`, which generates names as before. The new strategy is `foreign_key`.

```php
return [
    '*' => [
        // ...
        'relation_name_strategy' => 'foreign_key'
    ]
];
```