### PR TITLE
Add constants block generation

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -336,6 +336,26 @@ return [
     ],
 
     /*
+     |--------------------------------------------------------------------------
+     | Determines need or not to generate constants with properties names like
+     |
+     | ...
+     | const AGE = 'age';
+     | const USER_NAME = 'user_name';
+     | ...
+     |
+     | that later can be used in QueryBuilder like
+     |
+     | ...
+     | $builder->select([User::USER_NAME])->where(User::AGE, '<=', 18);
+     | ...
+     |
+     | that helps to avoid typos in strings when typing field names and allows to use
+     | code competition with available model's field names.
+     */
+    'with_property_constants' => false,
+
+    /*
     |--------------------------------------------------------------------------
     | Database Specifics
     |--------------------------------------------------------------------------

--- a/config/models.php
+++ b/config/models.php
@@ -333,27 +333,27 @@ return [
 
         'relation_name_strategy' => 'related',
         // 'relation_name_strategy' => 'foreign_key',
-    ],
 
-    /*
-     |--------------------------------------------------------------------------
-     | Determines need or not to generate constants with properties names like
-     |
-     | ...
-     | const AGE = 'age';
-     | const USER_NAME = 'user_name';
-     | ...
-     |
-     | that later can be used in QueryBuilder like
-     |
-     | ...
-     | $builder->select([User::USER_NAME])->where(User::AGE, '<=', 18);
-     | ...
-     |
-     | that helps to avoid typos in strings when typing field names and allows to use
-     | code competition with available model's field names.
-     */
-    'with_property_constants' => false,
+        /*
+         |--------------------------------------------------------------------------
+         | Determines need or not to generate constants with properties names like
+         |
+         | ...
+         | const AGE = 'age';
+         | const USER_NAME = 'user_name';
+         | ...
+         |
+         | that later can be used in QueryBuilder like
+         |
+         | ...
+         | $builder->select([User::USER_NAME])->where(User::AGE, '<=', 18);
+         | ...
+         |
+         | that helps to avoid typos in strings when typing field names and allows to use
+         | code competition with available model's field names.
+         */
+        'with_property_constants' => false,
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -302,17 +302,33 @@ class Factory
             $body .= $this->class->mixin($trait);
         }
 
+        $excludedConstants = [];
+
         if ($model->hasCustomCreatedAtField()) {
             $body .= $this->class->constant('CREATED_AT', $model->getCreatedAtField());
+            $excludedConstants[] = $model->getCreatedAtField();
         }
 
         if ($model->hasCustomUpdatedAtField()) {
             $body .= $this->class->constant('UPDATED_AT', $model->getUpdatedAtField());
+            $excludedConstants[] = $model->getUpdatedAtField();
         }
 
         if ($model->hasCustomDeletedAtField()) {
             $body .= $this->class->constant('DELETED_AT', $model->getDeletedAtField());
+            $excludedConstants[] = $model->getDeletedAtField();
         }
+
+        if ($this->config($model->getBlueprint(), 'with_property_constants', false)) {
+            // Take all properties and exclude already added constants with timestamps.
+            $properties = array_keys($model->getProperties());
+            $properties = array_diff($properties, $excludedConstants);
+
+            foreach ($properties as $property) {
+                $body .= $this->class->constant(strtoupper($property), $property);
+            }
+        }
+
 
         $body = trim($body, "\n");
         // Separate constants from fields only if there are constants.

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -319,7 +319,7 @@ class Factory
             $excludedConstants[] = $model->getDeletedAtField();
         }
 
-        if ($this->config($model->getBlueprint(), 'with_property_constants', false)) {
+        if ($model->usesPropertyConstants()) {
             // Take all properties and exclude already added constants with timestamps.
             $properties = array_keys($model->getProperties());
             $properties = array_diff($properties, $excludedConstants);
@@ -328,7 +328,6 @@ class Factory
                 $body .= $this->class->constant(strtoupper($property), $property);
             }
         }
-
 
         $body = trim($body, "\n");
         // Separate constants from fields only if there are constants.

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -252,6 +252,8 @@ class Model
         // TODO: Check type cast is OK
         $cast = $column->type;
 
+        $propertyName = $this->usesPropertyConstants() ? 'self::'.strtoupper($column->name) : $column->name;
+
         // Due to some casting problems when converting null to a Carbon instance,
         // we are going to treat Soft Deletes field as string.
         if ($column->name == $this->getDeletedAtField()) {
@@ -260,26 +262,26 @@ class Model
 
         // Track dates
         if ($cast == 'date') {
-            $this->dates[] = $column->name;
+            $this->dates[] = $propertyName;
         }
         // Track attribute casts
         elseif ($cast != 'string') {
-            $this->casts[$column->name] = $cast;
+            $this->casts[$propertyName] = $cast;
         }
 
         foreach ($this->config('casts', []) as $pattern => $casting) {
             if (Str::is($pattern, $column->name)) {
-                $this->casts[$column->name] = $cast = $casting;
+                $this->casts[$propertyName] = $cast = $casting;
                 break;
             }
         }
 
         if ($this->isHidden($column->name)) {
-            $this->hidden[] = $column->name;
+            $this->hidden[] = $propertyName;
         }
 
         if ($this->isFillable($column->name)) {
-            $this->fillable[] = $column->name;
+            $this->fillable[] = $propertyName;
         }
 
         $this->mutate($column->name);
@@ -1139,6 +1141,14 @@ class Model
     public function usesBaseFiles()
     {
         return $this->config('base_files', false);
+    }
+
+    /**
+     * @return bool
+     */
+    public function usesPropertyConstants()
+    {
+        return $this->config('with_property_constants', false);
     }
 
     /**

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -7,11 +7,11 @@
 
 namespace Reliese\Coders\Model\Relations;
 
-use Illuminate\Support\Str;
-use Reliese\Support\Dumper;
 use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
 use Reliese\Coders\Model\Model;
 use Reliese\Coders\Model\Relation;
+use Reliese\Support\Dumper;
 
 class BelongsTo implements Relation
 {
@@ -76,11 +76,17 @@ class BelongsTo implements Relation
         $body .= $this->related->getQualifiedUserClassName().'::class';
 
         if ($this->needsForeignKey()) {
-            $body .= ', '.Dumper::export($this->foreignKey());
+            $foreignKey = $this->parent->usesPropertyConstants()
+                ? $this->parent->getQualifiedUserClassName() . '::' . strtoupper($this->foreignKey())
+                : $this->foreignKey();
+            $body .= ', '.Dumper::export($foreignKey);
         }
 
         if ($this->needsOtherKey()) {
-            $body .= ', '.Dumper::export($this->otherKey());
+            $otherKey = $this->related->usesPropertyConstants()
+                ? $this->related->getQualifiedUserClassName() . '::' . strtoupper($this->otherKey())
+                : $this->otherKey();
+            $body .= ', '.Dumper::export($otherKey);
         }
 
         $body .= ')';

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -7,11 +7,11 @@
 
 namespace Reliese\Coders\Model\Relations;
 
-use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
+use Reliese\Support\Dumper;
+use Illuminate\Support\Fluent;
 use Reliese\Coders\Model\Model;
 use Reliese\Coders\Model\Relation;
-use Reliese\Support\Dumper;
 
 class BelongsTo implements Relation
 {
@@ -77,14 +77,14 @@ class BelongsTo implements Relation
 
         if ($this->needsForeignKey()) {
             $foreignKey = $this->parent->usesPropertyConstants()
-                ? $this->parent->getQualifiedUserClassName() . '::' . strtoupper($this->foreignKey())
+                ? $this->parent->getQualifiedUserClassName().'::'.strtoupper($this->foreignKey())
                 : $this->foreignKey();
             $body .= ', '.Dumper::export($foreignKey);
         }
 
         if ($this->needsOtherKey()) {
             $otherKey = $this->related->usesPropertyConstants()
-                ? $this->related->getQualifiedUserClassName() . '::' . strtoupper($this->otherKey())
+                ? $this->related->getQualifiedUserClassName().'::'.strtoupper($this->otherKey())
                 : $this->otherKey();
             $body .= ', '.Dumper::export($otherKey);
         }

--- a/src/Coders/Model/Relations/BelongsToMany.php
+++ b/src/Coders/Model/Relations/BelongsToMany.php
@@ -7,12 +7,12 @@
 
 namespace Reliese\Coders\Model\Relations;
 
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
+use Reliese\Support\Dumper;
+use Illuminate\Support\Fluent;
 use Reliese\Coders\Model\Model;
 use Reliese\Coders\Model\Relation;
-use Reliese\Support\Dumper;
+use Illuminate\Database\Eloquent\Collection;
 
 class BelongsToMany implements Relation
 {
@@ -69,7 +69,7 @@ class BelongsToMany implements Relation
      */
     public function hint()
     {
-        return '\\' . Collection::class;
+        return '\\'.Collection::class;
     }
 
     /**
@@ -91,24 +91,24 @@ class BelongsToMany implements Relation
     {
         $body = 'return $this->belongsToMany(';
 
-        $body .= $this->reference->getQualifiedUserClassName() . '::class';
+        $body .= $this->reference->getQualifiedUserClassName().'::class';
 
         if ($this->needsPivotTable()) {
-            $body .= ', ' . Dumper::export($this->pivotTable());
+            $body .= ', '.Dumper::export($this->pivotTable());
         }
 
         if ($this->needsForeignKey()) {
             $foreignKey = $this->parent->usesPropertyConstants()
-                ? $this->reference->getQualifiedUserClassName() . '::' . strtoupper($this->foreignKey())
+                ? $this->reference->getQualifiedUserClassName().'::'.strtoupper($this->foreignKey())
                 : $this->foreignKey();
-            $body .= ', ' . Dumper::export($foreignKey);
+            $body .= ', '.Dumper::export($foreignKey);
         }
 
         if ($this->needsOtherKey()) {
             $otherKey = $this->reference->usesPropertyConstants()
-                ? $this->reference->getQualifiedUserClassName() . '::' . strtoupper($this->otherKey())
+                ? $this->reference->getQualifiedUserClassName().'::'.strtoupper($this->otherKey())
                 : $this->otherKey();
-            $body .= ', ' . Dumper::export($otherKey);
+            $body .= ', '.Dumper::export($otherKey);
         }
 
         $body .= ')';
@@ -116,7 +116,7 @@ class BelongsToMany implements Relation
         $fields = $this->getPivotFields();
 
         if (!empty($fields)) {
-            $body .= "\n\t\t\t\t\t->withPivot(" . $this->parametrize($fields) . ')';
+            $body .= "\n\t\t\t\t\t->withPivot(".$this->parametrize($fields).')';
         }
 
         if ($this->pivot->usesTimestamps()) {
@@ -157,7 +157,7 @@ class BelongsToMany implements Relation
      */
     protected function needsForeignKey()
     {
-        $defaultForeignKey = $this->parentRecordName() . '_id';
+        $defaultForeignKey = $this->parentRecordName().'_id';
 
         return $this->foreignKey() != $defaultForeignKey || $this->needsOtherKey();
     }
@@ -175,7 +175,7 @@ class BelongsToMany implements Relation
      */
     protected function needsOtherKey()
     {
-        $defaultOtherKey = $this->referenceRecordName() . '_id';
+        $defaultOtherKey = $this->referenceRecordName().'_id';
 
         return $this->otherKey() != $defaultOtherKey;
     }
@@ -225,7 +225,7 @@ class BelongsToMany implements Relation
     {
         return (string)implode(', ', array_map(function ($field) {
             $field = $this->reference->usesPropertyConstants()
-                ? $this->pivot->getQualifiedUserClassName() . '::' . strtoupper($field)
+                ? $this->pivot->getQualifiedUserClassName().'::'.strtoupper($field)
                 : $field;
 
             return Dumper::export($field);

--- a/src/Coders/Model/Relations/BelongsToMany.php
+++ b/src/Coders/Model/Relations/BelongsToMany.php
@@ -115,7 +115,7 @@ class BelongsToMany implements Relation
 
         $fields = $this->getPivotFields();
 
-        if (!empty($fields)) {
+        if (! empty($fields)) {
             $body .= "\n\t\t\t\t\t->withPivot(".$this->parametrize($fields).')';
         }
 
@@ -223,7 +223,7 @@ class BelongsToMany implements Relation
      */
     private function parametrize($fields = [])
     {
-        return (string)implode(', ', array_map(function ($field) {
+        return (string) implode(', ', array_map(function ($field) {
             $field = $this->reference->usesPropertyConstants()
                 ? $this->pivot->getQualifiedUserClassName().'::'.strtoupper($field)
                 : $field;

--- a/src/Coders/Model/Relations/HasOneOrMany.php
+++ b/src/Coders/Model/Relations/HasOneOrMany.php
@@ -63,11 +63,17 @@ abstract class HasOneOrMany implements Relation
         $body .= $this->related->getQualifiedUserClassName().'::class';
 
         if ($this->needsForeignKey()) {
-            $body .= ', '.Dumper::export($this->foreignKey());
+            $foreignKey = $this->parent->usesPropertyConstants()
+                ? $this->related->getQualifiedUserClassName() . '::' . strtoupper($this->foreignKey())
+                : $this->foreignKey();
+            $body .= ', '.Dumper::export($foreignKey);
         }
 
         if ($this->needsLocalKey()) {
-            $body .= ', '.Dumper::export($this->localKey());
+            $localKey = $this->related->usesPropertyConstants()
+                ? $this->related->getQualifiedUserClassName() . '::' . strtoupper($this->localKey())
+                : $this->localKey();
+            $body .= ', '.Dumper::export($localKey);
         }
 
         $body .= ');';

--- a/src/Coders/Model/Relations/HasOneOrMany.php
+++ b/src/Coders/Model/Relations/HasOneOrMany.php
@@ -64,14 +64,14 @@ abstract class HasOneOrMany implements Relation
 
         if ($this->needsForeignKey()) {
             $foreignKey = $this->parent->usesPropertyConstants()
-                ? $this->related->getQualifiedUserClassName() . '::' . strtoupper($this->foreignKey())
+                ? $this->related->getQualifiedUserClassName().'::'.strtoupper($this->foreignKey())
                 : $this->foreignKey();
             $body .= ', '.Dumper::export($foreignKey);
         }
 
         if ($this->needsLocalKey()) {
             $localKey = $this->related->usesPropertyConstants()
-                ? $this->related->getQualifiedUserClassName() . '::' . strtoupper($this->localKey())
+                ? $this->related->getQualifiedUserClassName().'::'.strtoupper($this->localKey())
                 : $this->localKey();
             $body .= ', '.Dumper::export($localKey);
         }

--- a/src/Support/Dumper.php
+++ b/src/Support/Dumper.php
@@ -10,6 +10,18 @@ namespace Reliese\Support;
 class Dumper
 {
     /**
+     * Analyzed passed value and returns true if passed value uses class static call.
+     *
+     * @param mixed $value Value to check
+     *
+     * @return bool
+     */
+    private static function hasStaticCall($value)
+    {
+        return is_string($value) && strpos($value, '::') !== false;
+    }
+
+    /**
      * @param mixed $value
      * @param int $tabs
      *
@@ -27,13 +39,15 @@ class Dumper
                     return static::export($value, $tabs + 1);
                 }
 
-                return "'$key' => ".static::export($value, $tabs + 1);
+                $key = static::hasStaticCall($key) ? $key : "'$key'";
+
+                return "$key => ".static::export($value, $tabs + 1);
             }, $value, $keys);
 
             return "[\n$indent".implode(",\n$indent", $array)."\n$closingIndent]";
         }
 
         // Default variable exporting
-        return var_export($value, true);
+        return static::hasStaticCall($value) ? $value : var_export($value, true);
     }
 }


### PR DESCRIPTION
Determines need or not to generate constants with properties names like

```php
...
const AGE = 'age';
const USER_NAME = 'user_name';
...
```

that later can be used in QueryBuilder like

```php
...
$builder->select([User::USER_NAME])->where(User::AGE, '<=', 18);
...
```

that helps to avoid typos in strings when typing field names and allows to use
code competition with available model's field names.