### PR TITLE
remove count from Model.php

### DIFF
--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -745,7 +745,7 @@ class Model
      */
     public function hasCustomPrimaryKey()
     {
-        return count($this->primaryKeys->columns) == 1 &&
+        return ($this->primaryKeys->columns) == 1 &&
                $this->getPrimaryKey() != $this->getDefaultPrimaryKeyField();
     }
 


### PR DESCRIPTION
no need to use count here
fix error for php >7
 count(): Parameter must be an array or an object that implements Countable.


you can remove `count `from this and the value gonna be same

 ```
public function hasCustomPrimaryKey()
    {
        return count($this->primaryKeys->columns) == 1 &&
               $this->getPrimaryKey() != $this->getDefaultPrimaryKeyField();
    }
```