### PR TITLE
Fix #92 Command fails if a table doesn't have AI PK column.

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -24,7 +24,7 @@ class Factory
     /**
      * @var \Reliese\Meta\SchemaManager
      */
-    protected $schemas;
+    protected $schemas = [];
 
     /**
      * @var \Illuminate\Filesystem\Filesystem

--- a/src/Meta/Blueprint.php
+++ b/src/Meta/Blueprint.php
@@ -208,7 +208,7 @@ class Blueprint
             return current($this->unique);
         }
 
-        $nullPrimaryKey = new Fluent();
+        $nullPrimaryKey = new Fluent(['columns' => []]);
 
         return $nullPrimaryKey;
     }


### PR DESCRIPTION
Blueprint sets up a new Fluent without ensuring it has an array of `columns`,
which is a required attribute. This modifies a call to a `Fluent` constructor
providing a null array `columns.`

Factory declares `$schema` property which never instantiated, and is required to
be an array. This modifies the declaration to provide instantiation of a null array.