### PR TITLE
fixed  ErrorException  : count(): Parameter must be an array or an object that implements Countable

### DIFF
--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -784,8 +784,11 @@ class Model
      */
     public function hasCustomPrimaryKey()
     {
+        if($this->primaryKeys->columns) {
         return count($this->primaryKeys->columns) == 1 &&
                $this->getPrimaryKey() != $this->getDefaultPrimaryKeyField();
+        }
+        return;
     }
 
     /**


### PR DESCRIPTION
fixed  ErrorException  : count(): Parameter must be an array or an object that implements Countable on php 7.2 when generate model