### PR TITLE
Haystack and needles are backwards in Classify

### DIFF
--- a/src/Support/Classify.php
+++ b/src/Support/Classify.php
@@ -73,7 +73,7 @@ class Classify
 
     public function mixin($class)
     {
-        if (Str::startsWith('\\', $class)) {
+        if (Str::startsWith($class, '\\')) {
             $class = Str::replaceFirst('\\', '', $class);
         }
 


### PR DESCRIPTION
Find a needle in a haystack.

The way the line is written, you are searching if '\\' begins with $class, not the other way around.

From https://laravel.com/api/5.6/Illuminate/Support/Str.html#method_startsWith : `static bool startsWith(string $haystack, string|array $needles)`