### PR TITLE
Resolve issue with constant names generation for camelCased table fields

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -390,7 +390,8 @@ class Factory
             $properties = array_diff($properties, $excludedConstants);
 
             foreach ($properties as $property) {
-                $body .= $this->class->constant(strtoupper($property), $property);
+                $constantName = Str::upper(Str::snake($property));
+                $body .= $this->class->constant($constantName, $property);
             }
         }
 


### PR DESCRIPTION
If table uses *camelCased* fields names than, for example, for field *userId*  constant **USERID** will be generated. This PR will resolve this issue and new constant name will be **USER_ID**