### PR TITLE
Prevent plugin from scanning all schemas in a HUGE database!

### DIFF
--- a/src/Meta/SchemaManager.php
+++ b/src/Meta/SchemaManager.php
@@ -126,6 +126,12 @@ class SchemaManager implements IteratorAggregate
      */
     public function getIterator()
     {
-        return new ArrayIterator($this->schemas);
+        $schemas = forward_static_call([$this->getMapper(), 'schemas'], $this->connection);
+
+        foreach ($schemas as $schema) {
+            $this->make($schema);
+        }
+
+        return new ArrayIterator($this->schemas = $schemas);
     }
 }

--- a/src/Meta/SchemaManager.php
+++ b/src/Meta/SchemaManager.php
@@ -56,12 +56,6 @@ class SchemaManager implements IteratorAggregate
         if (! $this->hasMapping()) {
             throw new RuntimeException("There is no Schema Mapper registered for [{$this->type()}] connection.");
         }
-
-        $schemas = forward_static_call([$this->getMapper(), 'schemas'], $this->connection);
-
-        foreach ($schemas as $schema) {
-            $this->make($schema);
-        }
     }
 
     /**


### PR DESCRIPTION
I found that SchemaManager::boot() runs pretty slow if your database is big, even when schema name has been provided.

This commit is about preventing SchemaManager from scanning all schemata in a HUGE database.