### PR TITLE
Lack one reference method when two FKs in a table references to a same table

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -458,8 +458,8 @@ class Factory
             $body .= $this->class->method($mutation->name(), $mutation->body(), ['before' => "\n"]);
         }
 
-        foreach ($model->getRelations() as $constraint) {
-            $body .= $this->class->method($constraint->name(), $constraint->body(), ['before' => "\n"]);
+        foreach ($model->getRelations() as $k => $constraint) {
+            $body .= $this->class->method(Str::camel($k), $constraint->body(), ['before' => "\n"]);
         }
 
         // Make sure there not undesired line breaks

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -232,7 +232,7 @@ class Model
         foreach ($this->blueprint->relations() as $relation) {
             $model = $this->makeRelationModel($relation);
             $belongsTo = new BelongsTo($relation, $this, $model);
-            $this->relations[$belongsTo->name()] = $belongsTo;
+            $this->relations[implode('_', $relation->get('columns'))] = $belongsTo;
         }
 
         foreach ($this->factory->referencing($this) as $related) {


### PR DESCRIPTION
When I have two columns in a table that FK to a same table, the output model will lack one reference method.