### PR TITLE
Table without PrimaryKey not working

### DIFF
--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -784,7 +784,7 @@ class Model
      */
     public function hasCustomPrimaryKey()
     {
-        return count($this->primaryKeys->columns) == 1 &&
+        return count(empty($this->primaryKeys->columns)?[]:$this->primaryKeys->columns) == 1 &&
                $this->getPrimaryKey() != $this->getDefaultPrimaryKeyField();
     }
 


### PR DESCRIPTION
I simply implemented the condition to return an empty array when there are any Primary Key and the procedure works fine. Line 787