### PR TITLE
Set nullable fields as nullable in the docblock

### DIFF
--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -292,7 +292,7 @@ class Model
         }
 
         // Track PHP type hints
-        $hint = $this->phpTypeHint($cast);
+        $hint = $this->phpTypeHint($cast, $column->nullable);
         $this->properties[$column->name] = $hint;
 
         if ($column->name == $this->getPrimaryKey()) {
@@ -333,28 +333,40 @@ class Model
 
     /**
      * @param string $castType
+     * @param bool $nullable
      *
      * @todo Make tests
      *
      * @return string
      */
-    public function phpTypeHint($castType)
+    public function phpTypeHint($castType, $nullable)
     {
+        $type = $castType;
+
         switch ($castType) {
             case 'object':
-                return '\stdClass';
+                $type = '\stdClass';
+                break;
             case 'array':
             case 'json':
-                return 'array';
+                $type = 'array';
+                break;
             case 'collection':
-                return '\Illuminate\Support\Collection';
+                $type = '\Illuminate\Support\Collection';
+                break;
             case 'date':
-                return '\Carbon\Carbon';
+                $type = '\Carbon\Carbon';
+                break;
             case 'binary':
-                return 'string';
-            default:
-                return $castType;
+                $type = 'string';
+                break;
         }
+
+        if ($nullable) {
+            return $type.'|null';
+        }
+
+        return $type;
     }
 
     /**

--- a/tests/Coders/Console/Model/ModelTest.php
+++ b/tests/Coders/Console/Model/ModelTest.php
@@ -12,40 +12,40 @@ class ModelTest extends TestCase
             'Non-nullable int' => [
                 'castType' => 'int',
                 'nullable' => false,
-                'expect' => 'int'
+                'expect' => 'int',
             ],
             'Nullable int' => [
                 'castType' => 'int',
                 'nullable' => true,
-                'expect' => 'int|null'
+                'expect' => 'int|null',
             ],
             'Non-nullable json' => [
                 'castType' => 'json',
                 'nullable' => false,
-                'expect' => 'array'
+                'expect' => 'array',
             ],
             'Nullable json' => [
                 'castType' => 'json',
                 'nullable' => true,
-                'expect' => 'array|null'
+                'expect' => 'array|null',
             ],
             'Non-nullable date' => [
                 'castType' => 'date',
                 'nullable' => false,
-                'expect' => '\Carbon\Carbon'
+                'expect' => '\Carbon\Carbon',
             ],
             'Nullable date' => [
                 'castType' => 'date',
                 'nullable' => true,
-                'expect' => '\Carbon\Carbon|null'
-            ]
+                'expect' => '\Carbon\Carbon|null',
+            ],
         ];
     }
 
     /**
      * @dataProvider dataForTestPhpTypeHint
      *
-     * @param string$castType
+     * @param string $castType
      * @param bool $nullable
      * @param string $expect
      */

--- a/tests/Coders/Console/Model/ModelTest.php
+++ b/tests/Coders/Console/Model/ModelTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Reliese\Coders\Model\Factory;
+use Reliese\Coders\Model\Model;
+use Reliese\Meta\Blueprint;
+
+class ModelTest extends TestCase
+{
+    public function dataForTestPhpTypeHint()
+    {
+        return [
+            'Non-nullable int' => [
+                'castType' => 'int',
+                'nullable' => false,
+                'expect' => 'int'
+            ],
+            'Nullable int' => [
+                'castType' => 'int',
+                'nullable' => true,
+                'expect' => 'int|null'
+            ],
+            'Non-nullable json' => [
+                'castType' => 'json',
+                'nullable' => false,
+                'expect' => 'array'
+            ],
+            'Nullable json' => [
+                'castType' => 'json',
+                'nullable' => true,
+                'expect' => 'array|null'
+            ],
+            'Non-nullable date' => [
+                'castType' => 'date',
+                'nullable' => false,
+                'expect' => '\Carbon\Carbon'
+            ],
+            'Nullable date' => [
+                'castType' => 'date',
+                'nullable' => true,
+                'expect' => '\Carbon\Carbon|null'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataForTestPhpTypeHint
+     *
+     * @param string$castType
+     * @param bool $nullable
+     * @param string $expect
+     */
+    public function testPhpTypeHint($castType, $nullable, $expect)
+    {
+        $model = new Model(
+            new Blueprint('test', 'test', 'test'),
+            new Factory(
+                \Mockery::mock(\Illuminate\Database\DatabaseManager::class),
+                \Mockery::mock(Illuminate\Filesystem\Filesystem::class),
+                \Mockery::mock(\Reliese\Support\Classify::class),
+                new \Reliese\Coders\Model\Config()
+            )
+        );
+
+        $result = $model->phpTypeHint($castType, $nullable);
+        $this->assertSame($expect, $result);
+    }
+}


### PR DESCRIPTION
Currently if a field is nullable in the db it will still be added to the dockblock like this:
```php
/**
 * @property int $something
 */
```

When it should be
```php
/**
 * @property int|null $something
 */
```
because it is possible for it to be null in the DB.

This is fixed in the PR