### PR TITLE
Allow alias on parent class

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -268,7 +268,7 @@ class Factory
         $usedClasses = array_unique($usedClasses);
         $usedClassesSection = $this->formatUsedClasses(
             $model->getBaseNamespace(),
-            $usedClasses, 
+            $usedClasses,
             $model->getClassName()
         );
         $template = str_replace('{{imports}}', $usedClassesSection, $template);
@@ -291,7 +291,7 @@ class Factory
             // Do not import classes from same namespace
             $namespacePattern = str_replace('\\', '\\\\', "/{$baseNamespace}\\[a-zA-Z0-9_]*/");
             if (! preg_match($namespacePattern, $usedClass)) {
-                
+
                     //Do not import classes with same name of className
                     preg_match('/\\\\[^\\\\]*$/', $usedClass, $matches, PREG_OFFSET_CAPTURE, 0);
                     $usedClassName = str_replace("\\", "", $matches[0][0]);
@@ -316,16 +316,22 @@ class Factory
      */
     private function extractUsedClasses(&$placeholder)
     {
-        $classNamespaceRegExp = '/([\\\\a-zA-Z0-9_]*\\\\[\\\\a-zA-Z0-9_]*)/';
+        $classNamespaceRegExp = '/([\\\\a-zA-Z0-9_]*\\\\[\\\\a-zA-Z0-9_]*( as [a-zA-Z0-9_]+)?)/';
         $matches = [];
         $usedInModelClasses = [];
         if (preg_match_all($classNamespaceRegExp, $placeholder, $matches)) {
             foreach ($matches[1] as $match) {
-                $usedClassName = $match;
-                $usedInModelClasses[] = trim($usedClassName, '\\');
-                $namespaceParts = explode('\\', $usedClassName);
-                $resultClassName = array_pop($namespaceParts);
-                $placeholder = str_replace($usedClassName, $resultClassName, $placeholder);
+                if (Str::contains($match, " as ")) {
+                    $parts = explode(" as ", $match);
+                    $usedInModelClasses[] = $match;
+                    $placeholder = $parts[1];
+                } else {
+                    $usedClassName = $match;
+                    $usedInModelClasses[] = trim($usedClassName, '\\');
+                    $namespaceParts = explode('\\', $usedClassName);
+                    $resultClassName = array_pop($namespaceParts);
+                    $placeholder = str_replace($usedClassName, $resultClassName, $placeholder);
+                }
             }
         }
 


### PR DESCRIPTION
This change allows the extension of `App\User` model with the class `Illuminate\Foundation\Auth\User` aliased as `Authenticatable` with the following configuration:

```php
<?php

return [
    '*' => [ \\ global configuration ],
    'database_name' => [
        "users" => [
            "parent" => 'Illuminate\Foundation\Auth\User as Authenticatable',
        ],
     ]
];
```

it will create the `App\User` (or `App\Model\User` or `App\Base\User`) class as follows:

```php
<?php

/**
 * Created by Reliese Model.
 */

namespace App\Base;

use Carbon\Carbon;
use Illuminate\Foundation\Auth\User as Authenticatable;

/**
 * Class User
 * 
 * @property int $id
 * @property string $name
 * @property string $email
 * @property string $password
 * @property string|null $remember_token
 * @property Carbon|null $created_at
 * @property Carbon|null $updated_at
 *
 * @package App\Base
 */
class User extends Authenticatable
{
    protected $table = 'users';
    // ...
```