### PR TITLE
Support connection specific config

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -427,6 +427,10 @@ return [
     | that will be generated from a specific connection. You can also nest
     | database and table specific configurations.
     |
+    | You may wish to use connection specific config for setting a parent
+    | model with a read only setup, or enforcing a different set of rules
+    | for a connection, e.g. using snake_case naming over CamelCase naming.
+    |
     | This supports nesting with the following key configuration values, in
     | reverse precedence order (i.e. the last one found becomes the value).
     |
@@ -440,8 +444,8 @@ return [
     */
 
 //    'connections' => [
-//        'testing' => [
-//            'parent' => \App\Models\MyBaseModel::class,
+//        'read_only_external' => [
+//            'parent' => \App\Models\ReadOnlyModel::class,
 //            'connection' => true,
 //            'users' => [
 //                'connection' => false,

--- a/config/models.php
+++ b/config/models.php
@@ -417,4 +417,40 @@ return [
     //         'use' => [],
     //     ]
     // ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Connection Specifics
+    |--------------------------------------------------------------------------
+    |
+    | In this section you may define the default configuration for each model
+    | that will be generated from a specific connection. You can also nest
+    | database and table specific configurations.
+    |
+    | This supports nesting with the following key configuration values, in
+    | reverse precedence order (i.e. the last one found becomes the value).
+    |
+    |       connections.{connection_name}.property
+    |       connections.{connection_name}.{database_name}.property
+    |       connections.{connection_name}.{table_name}.property
+    |       connections.{connection_name}.{database_name}.{table_name}.property
+    |
+    | These values will override those defined in the section above.
+    |
+    */
+
+//    'connections' => [
+//        'testing' => [
+//            'parent' => \App\Models\MyBaseModel::class,
+//            'connection' => true,
+//            'users' => [
+//                'connection' => false,
+//            ],
+//            'my_other_database' => [
+//                'password_resets' => [
+//                    'connection' => false,
+//                ]
+//            ]
+//        ],
+//    ],
 ];

--- a/src/Coders/Model/Config.php
+++ b/src/Coders/Model/Config.php
@@ -40,6 +40,10 @@ class Config
         $schema = Arr::get($this->config, "{$blueprint->schema()}.$key", $default);
         $specific = Arr::get($this->config, "{$blueprint->qualifiedTable()}.$key", $schema);
 
-        return $specific;
+        $connection =  Arr::get($this->config, "connections.{$blueprint->connection()}.$key", $specific);
+        $connectionSchema =  Arr::get($this->config, "connections.{$blueprint->connection()}.{$blueprint->schema()}.$key", $connection);
+        $connectionTable =  Arr::get($this->config, "connections.{$blueprint->connection()}.{$blueprint->table()}.$key", $connectionSchema);
+
+        return Arr::get($this->config, "connections.{$blueprint->connection()}.{$blueprint->qualifiedTable()}.$key", $connectionTable);
     }
 }

--- a/src/Coders/Model/Config.php
+++ b/src/Coders/Model/Config.php
@@ -36,14 +36,20 @@ class Config
      */
     public function get(Blueprint $blueprint, $key, $default = null)
     {
-        $default = Arr::get($this->config, "*.$key", $default);
-        $schema = Arr::get($this->config, "{$blueprint->schema()}.$key", $default);
-        $specific = Arr::get($this->config, "{$blueprint->qualifiedTable()}.$key", $schema);
+        $original = Arr::get($this->config, "*.$key", $default);
 
-        $connection =  Arr::get($this->config, "connections.{$blueprint->connection()}.$key", $specific);
-        $connectionSchema =  Arr::get($this->config, "connections.{$blueprint->connection()}.{$blueprint->schema()}.$key", $connection);
-        $connectionTable =  Arr::get($this->config, "connections.{$blueprint->connection()}.{$blueprint->table()}.$key", $connectionSchema);
+        $checkKeys = [
+            "{$blueprint->schema()}.$key",
+            "{$blueprint->qualifiedTable()}.$key",
+            "connections.{$blueprint->connection()}.$key",
+            "connections.{$blueprint->connection()}.{$blueprint->schema()}.$key",
+            "connections.{$blueprint->connection()}.{$blueprint->table()}.$key",
+        ];
 
-        return Arr::get($this->config, "connections.{$blueprint->connection()}.{$blueprint->qualifiedTable()}.$key", $connectionTable);
+        foreach ($checkKeys as $key) {
+            $original = Arr::get($this->config, $key, $original);
+        }
+
+        return $original;
     }
 }

--- a/tests/Coders/Model/ConfigTest.php
+++ b/tests/Coders/Model/ConfigTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Illuminate\Support\Arr;
 use PHPUnit\Framework\TestCase;
 use Reliese\Coders\Model\Config;
 use Reliese\Meta\Blueprint;
@@ -93,7 +92,103 @@ class ConfigTest extends TestCase
                 ],
                 'ctKey',
                 'Connection Table Value'
-            ]
+            ],
+            'Test Hierarchy Override for Schema' => [
+                [
+                    '*' => [
+                        'FirstKey' => 'Some Value'
+                    ],
+                    'test' => [
+                        'FirstKey' => 'A Second Value'
+                    ]
+                ],
+                'FirstKey',
+                'A Second Value'
+            ],
+            'Test Hierarchy Override for Qualified Table' => [
+                [
+                    '*' => [
+                        'FirstKey' => 'Some Value'
+                    ],
+                    'test' => [
+                        'FirstKey' => 'A Second Value',
+                        'my_table' => [
+                            'FirstKey' => 'A Third Value'
+                        ]
+                    ],
+                ],
+                'FirstKey',
+                'A Third Value'
+            ],
+            'Test Hierarchy Override for Connection Basic Key' => [
+                [
+                    '*' => [
+                        'FirstKey' => 'Some Value'
+                    ],
+                    'test' => [
+                        'FirstKey' => 'A Second Value',
+                        'my_table' => [
+                            'FirstKey' => 'A Third Value'
+                        ]
+                    ],
+                    'connections' => [
+                        'test_connection' => [
+                            'FirstKey' => 'A Fourth Value',
+                        ]
+                    ]
+                ],
+                'FirstKey',
+                'A Fourth Value'
+            ],
+            'Test Hierarchy Override for Connection Schema Key' => [
+                [
+                    '*' => [
+                        'FirstKey' => 'Some Value'
+                    ],
+                    'test' => [
+                        'FirstKey' => 'A Second Value',
+                        'my_table' => [
+                            'FirstKey' => 'A Third Value'
+                        ]
+                    ],
+                    'connections' => [
+                        'test_connection' => [
+                            'FirstKey' => 'A Fourth Value',
+                            'test' => [
+                                'FirstKey' => 'A Fifth Value'
+                            ]
+                        ]
+                    ]
+                ],
+                'FirstKey',
+                'A Fifth Value'
+            ],
+            'Test Hierarchy Override for Connection Table Key' => [
+                [
+                    '*' => [
+                        'FirstKey' => 'Some Value'
+                    ],
+                    'test' => [
+                        'FirstKey' => 'A Second Value',
+                        'my_table' => [
+                            'FirstKey' => 'A Third Value'
+                        ]
+                    ],
+                    'connections' => [
+                        'test_connection' => [
+                            'FirstKey' => 'A Fourth Value',
+                            'test' => [
+                                'FirstKey' => 'A Fifth Value',
+                            ],
+                            'my_table' => [
+                                'FirstKey' => 'A Sixth Value',
+                            ]
+                        ]
+                    ]
+                ],
+                'FirstKey',
+                'A Sixth Value'
+            ],
         ];
     }
 }

--- a/tests/Coders/Model/ConfigTest.php
+++ b/tests/Coders/Model/ConfigTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Illuminate\Support\Arr;
+use PHPUnit\Framework\TestCase;
+use Reliese\Coders\Model\Config;
+use Reliese\Meta\Blueprint;
+
+class ConfigTest extends TestCase
+{
+    /**
+     * @dataProvider provideDataForTestGet
+     *
+     * @param array $config
+     * @param string $key
+     * @param string|array|bool|int|float $expected
+     */
+    public function testGet($config, $key, $expected)
+    {
+        $config = new Config($config);
+
+        $baseBlueprint = Mockery::mock(Blueprint::class);
+        $baseBlueprint->shouldReceive('schema')->andReturn('test');
+        $baseBlueprint->shouldReceive('qualifiedTable')->andReturn('test.my_table');
+        $baseBlueprint->shouldReceive('connection')->andReturn('test_connection');
+        $baseBlueprint->shouldReceive('table')->andReturn('my_table');
+
+        $this->assertEquals($expected, $config->get($baseBlueprint, $key));
+    }
+
+    public function provideDataForTestGet()
+    {
+        return [
+            'Basic Key' => [
+                [
+                    '*' => [
+                        'Key' => 'Value'
+                    ],
+                ],
+                'Key',
+                'Value'
+            ],
+            'Schema Key' => [
+                [
+                    'test' => [
+                        'schemaKey' => 'Schema Value'
+                    ],
+                ],
+                'schemaKey',
+                'Schema Value'
+            ],
+            'Qualified Table Key' => [
+                [
+                    'test' => [
+                        'qfKey' => 'Qualified Table Value'
+                    ],
+                ],
+                'qfKey',
+                'Qualified Table Value'
+            ],
+            'Connection Basic Key' => [
+                [
+                    'connections' => [
+                        'test_connection' => [
+                            'cKey' => 'Connection Value'
+                        ],
+                    ]
+                ],
+                'cKey',
+                'Connection Value'
+            ],
+            'Connection Schema Key' => [
+                [
+                    'connections' => [
+                        'test_connection' => [
+                            'test' => [
+                                'csKey' => 'Connection Schema Value'
+                            ]
+                        ],
+                    ]
+                ],
+                'csKey',
+                'Connection Schema Value'
+            ],
+            'Connection Table Key' => [
+                [
+                    'connections' => [
+                        'test_connection' => [
+                            'my_table' => [
+                                'ctKey' => 'Connection Table Value'
+                            ]
+                        ],
+                    ]
+                ],
+                'ctKey',
+                'Connection Table Value'
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
This PR enables support for connection specific config, useful for if you want to modify config based on the connection defined from the `--connection` option.