### PR TITLE
Add backslash prefix to import checks

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -283,7 +283,7 @@ class Factory
         $imports = [];
         foreach ($dependencies as $dependencyClass) {
             // Skip when the same class
-            if ($dependencyClass == $model->getQualifiedUserClassName()) {
+            if ("\\" . ltrim($dependencyClass, "\\") == "\\" . ltrim($model->getQualifiedUserClassName(), "\\")) {
                 continue;
             }
 


### PR DESCRIPTION
This fixes the bug which the code can't eliminate the dependency where the class is defined as `App\ModelName` but the compared dependency has the format of `\App\ModelName` (with the leading backslash), which causes the fatal exception of; 

> "Fatal error: Cannot declare class App\Base\ModelName because the name is already in use in ..."