### PR TITLE
Improved relationship names when using foreign_key naming strategy

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -333,14 +333,19 @@ return [
                             generates Post::user() and User::posts()
         |
         | 'foreign_key' Use the foreign key as the relation name.
-        |                   (post.author --> user.id)
-        |                       generates Post::author() and User::posts_author()
-        |               Column id's are ignored.
+        |               This can help to provide more meaningful relationship names, and avoids naming conflicts
+        |               if you have more than one relationship between two tables.
         |                   (post.author_id --> user.id)
+        |                       generates Post::author() and User::posts_where_author()
+        |                   (post.editor_id --> user.id)
+        |                       generates Post::editor() and User::posts_where_editor()
+        |               ID suffixes can be omitted from foreign keys.
+        |                   (post.author --> user.id)
+        |                   (post.editor --> user.id)
         |                       generates the same as above.
-        |               When the foreign key is redundant, it is omited.
+        |               Where the foreign key matches the related table name, it behaves as per the 'related' strategy.
         |                   (post.user_id --> user.id)
-        |                       generates User::posts() and not User::posts_user()
+        |                       generates Post::user() and User::posts()
         */
 
         'relation_name_strategy' => 'related',

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -283,7 +283,7 @@ class Factory
         $imports = [];
         foreach ($dependencies as $dependencyClass) {
             // Skip when the same class
-            if ($dependencyClass == $model->getQualifiedUserClassName()) {
+            if ("\\" . ltrim($dependencyClass, "\\") == "\\" . ltrim($model->getQualifiedUserClassName(), "\\")) {
                 continue;
             }
 

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -283,7 +283,7 @@ class Factory
         $imports = [];
         foreach ($dependencies as $dependencyClass) {
             // Skip when the same class
-            if ("\\" . ltrim($dependencyClass, "\\") == "\\" . ltrim($model->getQualifiedUserClassName(), "\\")) {
+            if (trim($dependencyClass, "\\") == trim($model->getQualifiedUserClassName(), "\\")) {
                 continue;
             }
 

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -51,16 +51,11 @@ class BelongsTo implements Relation
     {
         switch ($this->parent->getRelationNameStrategy()) {
             case 'foreign_key':
-                $relationName = $this->foreignKey();
-                $primaryKey = $this->otherKey();
-                // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
-                if ($this->parent->usesSnakeAttributes()) {
-                    $lowerPrimaryKey = strtolower($primaryKey);
-                    $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
-                } else {
-                    $studlyPrimaryKey = Str::studly($primaryKey);
-                    $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
-                }
+                $relationName = RelationHelper::stripSuffixFromForeignKey(
+                    $this->parent->usesSnakeAttributes(),
+                    $this->otherKey(),
+                    $this->foreignKey()
+                );
                 break;
             default:
             case 'related':

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -7,11 +7,11 @@
 
 namespace Reliese\Coders\Model\Relations;
 
-use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
+use Reliese\Support\Dumper;
+use Illuminate\Support\Fluent;
 use Reliese\Coders\Model\Model;
 use Reliese\Coders\Model\Relation;
-use Reliese\Support\Dumper;
 
 class BelongsTo implements Relation
 {

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -49,15 +49,26 @@ class BelongsTo implements Relation
      */
     public function name()
     {
-        switch ($this->parent->getRelationNameStrategy()) {
-            case 'foreign_key':
-                $relationName = preg_replace("/[^a-zA-Z0-9]?{$this->otherKey()}$/", '', $this->foreignKey());
-                break;
-            default:
-            case 'related':
-                $relationName = $this->related->getClassName();
-                break;
-        }
+//        if ($this->related->getClassName() === 'Employee') {
+            $relationName = $this->foreignKey();
+            // chop off 'id'
+            if ($this->parent->usesSnakeAttributes()) {
+                $relationName = preg_replace('/_id$/', '', $relationName);
+            } else {
+                $relationName = preg_replace('/(Id)|(ID)$/', '', $relationName);
+            }
+
+
+//        }
+//        switch ($this->parent->getRelationNameStrategy()) {
+//            case 'foreign_key':
+//                $relationName = preg_replace("/[^a-zA-Z0-9]?{$this->otherKey()}$/", '', $this->foreignKey());
+//                break;
+//            default:
+//            case 'related':
+//                $relationName = $this->related->getClassName();
+//                break;
+//        }
 
         if ($this->parent->usesSnakeAttributes()) {
             return Str::snake($relationName);

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -71,6 +71,73 @@ class BelongsTo implements Relation
     }
 
     /**
+     * @return string
+     */
+    public function body()
+    {
+        $body = 'return $this->belongsTo(';
+
+        $body .= $this->related->getQualifiedUserClassName().'::class';
+
+        if ($this->needsForeignKey()) {
+            $foreignKey = $this->parent->usesPropertyConstants()
+                ? $this->parent->getQualifiedUserClassName().'::'.strtoupper($this->foreignKey())
+                : $this->foreignKey();
+            $body .= ', '.Dumper::export($foreignKey);
+        }
+
+        if ($this->needsOtherKey()) {
+            $otherKey = $this->related->usesPropertyConstants()
+                ? $this->related->getQualifiedUserClassName().'::'.strtoupper($this->otherKey())
+                : $this->otherKey();
+            $body .= ', '.Dumper::export($otherKey);
+        }
+
+        $body .= ')';
+
+        if ($this->hasCompositeOtherKey()) {
+            // We will assume that when this happens the referenced columns are a composite primary key
+            // or a composite unique key. Otherwise it should be a has-many relationship which is not
+            // supported at the moment. @todo: Improve relationship resolution.
+            foreach ($this->command->references as $index => $column) {
+                $body .= "\n\t\t\t\t\t->where(".
+                    Dumper::export($this->qualifiedOtherKey($index)).
+                    ", '=', ".
+                    Dumper::export($this->qualifiedForeignKey($index)).
+                    ')';
+            }
+        }
+
+        $body .= ';';
+
+        return $body;
+    }
+
+    /**
+     * @return string
+     */
+    public function hint()
+    {
+        $base =  $this->related->getQualifiedUserClassName();
+
+        if ($this->isNullable()) {
+            $base .= '|null';
+        }
+
+        return $base;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function needsForeignKey()
+    {
+        $defaultForeignKey = $this->related->getRecordName().'_id';
+
+        return $defaultForeignKey != $this->foreignKey() || $this->needsOtherKey();
+    }
+
+    /**
      * @param int $index
      *
      * @return string
@@ -85,62 +152,9 @@ class BelongsTo implements Relation
      *
      * @return string
      */
-    protected function otherKey($index = 0)
+    protected function qualifiedForeignKey($index = 0)
     {
-        return $this->command->references[$index];
-    }
-
-    /**
-     * @return string
-     */
-    public function body()
-    {
-        $body = 'return $this->belongsTo(';
-
-        $body .= $this->related->getQualifiedUserClassName() . '::class';
-
-        if ($this->needsForeignKey()) {
-            $foreignKey = $this->parent->usesPropertyConstants()
-                ? $this->parent->getQualifiedUserClassName() . '::' . strtoupper($this->foreignKey())
-                : $this->foreignKey();
-            $body .= ', ' . Dumper::export($foreignKey);
-        }
-
-        if ($this->needsOtherKey()) {
-            $otherKey = $this->related->usesPropertyConstants()
-                ? $this->related->getQualifiedUserClassName() . '::' . strtoupper($this->otherKey())
-                : $this->otherKey();
-            $body .= ', ' . Dumper::export($otherKey);
-        }
-
-        $body .= ')';
-
-        if ($this->hasCompositeOtherKey()) {
-            // We will assume that when this happens the referenced columns are a composite primary key
-            // or a composite unique key. Otherwise it should be a has-many relationship which is not
-            // supported at the moment. @todo: Improve relationship resolution.
-            foreach ($this->command->references as $index => $column) {
-                $body .= "\n\t\t\t\t\t->where(" .
-                         Dumper::export($this->qualifiedOtherKey($index)) .
-                         ", '=', " .
-                         Dumper::export($this->qualifiedForeignKey($index)) .
-                         ')';
-            }
-        }
-
-        $body .= ';';
-
-        return $body;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function needsForeignKey()
-    {
-        $defaultForeignKey = $this->related->getRecordName() . '_id';
-
-        return $defaultForeignKey != $this->foreignKey() || $this->needsOtherKey();
+        return $this->parent->getTable().'.'.$this->foreignKey($index);
     }
 
     /**
@@ -154,6 +168,26 @@ class BelongsTo implements Relation
     }
 
     /**
+     * @param int $index
+     *
+     * @return string
+     */
+    protected function otherKey($index = 0)
+    {
+        return $this->command->references[$index];
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return string
+     */
+    protected function qualifiedOtherKey($index = 0)
+    {
+        return $this->related->getTable().'.'.$this->otherKey($index);
+    }
+
+    /**
      * Whether the "other key" is a composite foreign key.
      *
      * @return bool
@@ -164,44 +198,10 @@ class BelongsTo implements Relation
     }
 
     /**
-     * @param int $index
-     *
-     * @return string
-     */
-    protected function qualifiedOtherKey($index = 0)
-    {
-        return $this->related->getTable() . '.' . $this->otherKey($index);
-    }
-
-    /**
-     * @param int $index
-     *
-     * @return string
-     */
-    protected function qualifiedForeignKey($index = 0)
-    {
-        return $this->parent->getTable() . '.' . $this->foreignKey($index);
-    }
-
-    /**
-     * @return string
-     */
-    public function hint()
-    {
-        $base = $this->related->getQualifiedUserClassName();
-
-        if ($this->isNullable()) {
-            $base .= '|null';
-        }
-
-        return $base;
-    }
-
-    /**
      * @return bool
      */
     private function isNullable()
     {
-        return (bool)$this->parent->getBlueprint()->column($this->foreignKey())->get('nullable');
+        return (bool) $this->parent->getBlueprint()->column($this->foreignKey())->get('nullable');
     }
 }

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -49,27 +49,24 @@ class BelongsTo implements Relation
      */
     public function name()
     {
-        $relationName = $this->foreignKey();
-        $primaryKey = $this->otherKey();
-        // chop off 'id'
-        if ($this->parent->usesSnakeAttributes()) {
-            $lowerPrimaryKey = strtolower($primaryKey);
-            $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
-        } else {
-            $studlyPrimaryKey = Str::studly($primaryKey);
-            $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
+        switch ($this->parent->getRelationNameStrategy()) {
+            case 'foreign_key':
+                $relationName = $this->foreignKey();
+                $primaryKey = $this->otherKey();
+                // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
+                if ($this->parent->usesSnakeAttributes()) {
+                    $lowerPrimaryKey = strtolower($primaryKey);
+                    $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
+                } else {
+                    $studlyPrimaryKey = Str::studly($primaryKey);
+                    $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
+                }
+                break;
+            default:
+            case 'related':
+                $relationName = $this->related->getClassName();
+                break;
         }
-
-
-//        switch ($this->parent->getRelationNameStrategy()) {
-//            case 'foreign_key':
-//                $relationName = preg_replace("/[^a-zA-Z0-9]?{$this->otherKey()}$/", '', $this->foreignKey());
-//                break;
-//            default:
-//            case 'related':
-//                $relationName = $this->related->getClassName();
-//                break;
-//        }
 
         if ($this->parent->usesSnakeAttributes()) {
             return Str::snake($relationName);

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -25,50 +25,29 @@ class HasMany extends HasOneOrMany
      */
     public function name()
     {
-        $relationName = $this->foreignKey();
-        $primaryKey = $this->localKey();
-        // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
-        if ($this->parent->usesSnakeAttributes()) {
-            $lowerPrimaryKey = strtolower($primaryKey);
-            $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
-        } else {
-            $studlyPrimaryKey = Str::studly($primaryKey);
-            $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
+        switch ($this->parent->getRelationNameStrategy()) {
+            case 'foreign_key':
+                $relationName = $this->foreignKey();
+                $primaryKey = $this->localKey();
+                // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
+                if ($this->parent->usesSnakeAttributes()) {
+                    $lowerPrimaryKey = strtolower($primaryKey);
+                    $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
+                } else {
+                    $studlyPrimaryKey = Str::studly($primaryKey);
+                    $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
+                }
+                if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
+                    $relationName = Str::plural($this->related->getClassName());
+                } else {
+                    $relationName = Str::plural($this->related->getClassName()) . 'Where' . ucfirst(Str::singular($relationName));
+                }
+                break;
+            default:
+            case 'related':
+                $relationName = Str::plural($this->related->getClassName());
+                break;
         }
-
-        if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
-            $relationName = Str::plural($this->related->getClassName());
-        } else {
-            $relationName = Str::plural($this->related->getClassName()) . 'Where' . ucfirst(Str::singular($relationName));
-        }
-
-//        if ($this->parent->shouldPluralizeTableName()) {
-//            $relationBaseName = Str::plural(Str::singular($this->related->getTable(true)));
-//        } else {
-//            $relationBaseName = $this->related->getTable(true);
-//        }
-//
-//        if ($this->parent->shouldLowerCaseTableName()) {
-//            $relationBaseName = strtolower($relationBaseName);
-//        }
-//
-//        switch ($this->parent->getRelationNameStrategy()) {
-//            case 'foreign_key':
-//                $suffix = preg_replace("/[^a-zA-Z0-9]?{$this->localKey()}$/", '', $this->foreignKey());
-//
-//                $relationName = $relationBaseName;
-//
-//                // Don't make relations such as users_user, just leave it as 'users'.
-//                if ($this->parent->getTable(true) !== $suffix) {
-//                    $relationName .= "_{$suffix}";
-//                }
-//
-//                break;
-//            case 'related':
-//            default:
-//                $relationName = $relationBaseName;
-//                break;
-//        }
 
         if ($this->parent->usesSnakeAttributes()) {
             return Str::snake($relationName);

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -7,8 +7,8 @@
 
 namespace Reliese\Coders\Model\Relations;
 
-use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
 
 class HasMany extends HasOneOrMany
 {
@@ -26,12 +26,14 @@ class HasMany extends HasOneOrMany
     public function name()
     {
         $relationName = $this->foreignKey();
-
-        // chop off 'id'
+        $primaryKey = $this->localKey();
+        // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
         if ($this->parent->usesSnakeAttributes()) {
-            $relationName = preg_replace('/_id$/', '', $relationName);
+            $lowerPrimaryKey = strtolower($primaryKey);
+            $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
         } else {
-            $relationName = preg_replace('/(Id)|(ID)$/', '', $relationName);
+            $studlyPrimaryKey = Str::studly($primaryKey);
+            $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
         }
 
         if (strtolower($relationName) === strtolower($this->parent->getClassName())) {

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -25,33 +25,48 @@ class HasMany extends HasOneOrMany
      */
     public function name()
     {
-        if ($this->parent->shouldPluralizeTableName()) {
-            $relationBaseName = Str::plural(Str::singular($this->related->getTable(true)));
+        $relationName = $this->foreignKey();
+
+        // chop off 'id'
+        if ($this->parent->usesSnakeAttributes()) {
+            $relationName = preg_replace('/_id$/', '', $relationName);
         } else {
-            $relationBaseName = $this->related->getTable(true);
+            $relationName = preg_replace('/(Id)|(ID)$/', '', $relationName);
         }
 
-        if ($this->parent->shouldLowerCaseTableName()) {
-            $relationBaseName = strtolower($relationBaseName);
+        if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
+            $relationName = Str::plural($this->related->getClassName());
+        } else {
+            $relationName = Str::plural($this->related->getClassName()) . 'Where' . ucfirst(Str::singular($relationName));
         }
 
-        switch ($this->parent->getRelationNameStrategy()) {
-            case 'foreign_key':
-                $suffix = preg_replace("/[^a-zA-Z0-9]?{$this->localKey()}$/", '', $this->foreignKey());
-
-                $relationName = $relationBaseName;
-
-                // Don't make relations such as users_user, just leave it as 'users'.
-                if ($this->parent->getTable(true) !== $suffix) {
-                    $relationName .= "_{$suffix}";
-                }
-
-                break;
-            case 'related':
-            default:
-                $relationName = $relationBaseName;
-                break;
-        }
+//        if ($this->parent->shouldPluralizeTableName()) {
+//            $relationBaseName = Str::plural(Str::singular($this->related->getTable(true)));
+//        } else {
+//            $relationBaseName = $this->related->getTable(true);
+//        }
+//
+//        if ($this->parent->shouldLowerCaseTableName()) {
+//            $relationBaseName = strtolower($relationBaseName);
+//        }
+//
+//        switch ($this->parent->getRelationNameStrategy()) {
+//            case 'foreign_key':
+//                $suffix = preg_replace("/[^a-zA-Z0-9]?{$this->localKey()}$/", '', $this->foreignKey());
+//
+//                $relationName = $relationBaseName;
+//
+//                // Don't make relations such as users_user, just leave it as 'users'.
+//                if ($this->parent->getTable(true) !== $suffix) {
+//                    $relationName .= "_{$suffix}";
+//                }
+//
+//                break;
+//            case 'related':
+//            default:
+//                $relationName = $relationBaseName;
+//                break;
+//        }
 
         if ($this->parent->usesSnakeAttributes()) {
             return Str::snake($relationName);

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -7,8 +7,8 @@
 
 namespace Reliese\Coders\Model\Relations;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Collection;
 
 class HasMany extends HasOneOrMany
 {

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -32,7 +32,7 @@ class HasMany extends HasOneOrMany
                     $this->localKey(),
                     $this->foreignKey()
                 );
-                if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
+                if (Str::snake($relationName) === Str::snake($this->parent->getClassName())) {
                     $relationName = Str::plural($this->related->getClassName());
                 } else {
                     $relationName = Str::plural($this->related->getClassName()) . 'Where' . ucfirst(Str::singular($relationName));

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -27,16 +27,11 @@ class HasMany extends HasOneOrMany
     {
         switch ($this->parent->getRelationNameStrategy()) {
             case 'foreign_key':
-                $relationName = $this->foreignKey();
-                $primaryKey = $this->localKey();
-                // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
-                if ($this->parent->usesSnakeAttributes()) {
-                    $lowerPrimaryKey = strtolower($primaryKey);
-                    $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
-                } else {
-                    $studlyPrimaryKey = Str::studly($primaryKey);
-                    $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
-                }
+                $relationName = RelationHelper::stripSuffixFromForeignKey(
+                    $this->parent->usesSnakeAttributes(),
+                    $this->localKey(),
+                    $this->foreignKey()
+                );
                 if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
                     $relationName = Str::plural($this->related->getClassName());
                 } else {

--- a/src/Coders/Model/Relations/RelationHelper.php
+++ b/src/Coders/Model/Relations/RelationHelper.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Reliese\Coders\Model\Relations;
+
+use Illuminate\Support\Str;
+
+/**
+ * General utility functions for dealing with relationships
+ */
+class RelationHelper
+{
+    /**
+     * Turns a column name like 'manager_id' into 'manager'; or 'lineManagerId' into 'lineManager'.
+     *
+     * @param bool $usesSnakeAttributes
+     * @param string $primaryKey
+     * @param string $foreignKey
+     * @return string
+     */
+    public static function stripSuffixFromForeignKey($usesSnakeAttributes, $primaryKey, $foreignKey)
+    {
+        if ($usesSnakeAttributes) {
+            $lowerPrimaryKey = strtolower($primaryKey);
+            return preg_replace('/(_)(' . $primaryKey . '|' . $lowerPrimaryKey . ')$/', '', $foreignKey);
+        } else {
+            $studlyPrimaryKey = Str::studly($primaryKey);
+            return preg_replace('/(' . $primaryKey . '|' . $studlyPrimaryKey . ')$/', '', $foreignKey);
+        }
+    }
+}

--- a/tests/Coders/Model/Relations/BelongsToTest.php
+++ b/tests/Coders/Model/Relations/BelongsToTest.php
@@ -11,11 +11,11 @@ class BelongsToTest extends TestCase
     {
         // usesSnakeAttributes, primaryKey, foreignKey, expected
         return [
-            // columns use snake_case
+            // columns use camelCase
             [false, 'id', 'lineManagerId', 'lineManager'],
             [false, 'Id', 'lineManagerId', 'lineManager'],
             [false, 'ID', 'lineManagerID', 'lineManager'],
-            // columns use camelCase
+            // columns use snake_case
             [true, 'id', 'line_manager_id', 'line_manager'],
             [true, 'ID', 'line_manager_id', 'line_manager'],
             // foreign keys without primary key suffix
@@ -36,10 +36,9 @@ class BelongsToTest extends TestCase
     {
         $relation = Mockery::mock(Fluent::class)->makePartial();
 
-        $modelMock = Mockery::mock(Model::class);
-        $relatedModel = $modelMock->makePartial();
+        $relatedModel = Mockery::mock(Model::class)->makePartial();
 
-        $subject = $modelMock->makePartial();
+        $subject = Mockery::mock(Model::class)->makePartial();
         $subject->shouldReceive('getRelationNameStrategy')->andReturn('foreign_key');
         $subject->shouldReceive('usesSnakeAttributes')->andReturn($usesSnakeAttributes);
 
@@ -76,11 +75,10 @@ class BelongsToTest extends TestCase
     {
         $relation = Mockery::mock(Fluent::class)->makePartial();
 
-        $modelMock = Mockery::mock(Model::class);
-        $relatedModel = $modelMock->makePartial();
+        $relatedModel = Mockery::mock(Model::class)->makePartial();
         $relatedModel->shouldReceive('getClassName')->andReturn($relatedClassName);
 
-        $subject = $modelMock->makePartial();
+        $subject = Mockery::mock(Model::class)->makePartial();
         $subject->shouldReceive('getRelationNameStrategy')->andReturn('related');
         $subject->shouldReceive('usesSnakeAttributes')->andReturn($usesSnakeAttributes);
 

--- a/tests/Coders/Model/Relations/BelongsToTest.php
+++ b/tests/Coders/Model/Relations/BelongsToTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Support\Fluent;
+use PHPUnit\Framework\TestCase;
+use Reliese\Coders\Model\Relations\BelongsTo;
+
+class BelongsToTest extends TestCase
+{
+    public function provideForeignKeyStrategyPermutations()
+    {
+        // usesSnakeAttributes, primaryKey, foreignKey, expected
+        return [
+            // columns use snake_case
+            [false, 'id', 'lineManagerId', 'lineManager'],
+            [false, 'Id', 'lineManagerId', 'lineManager'],
+            [false, 'ID', 'lineManagerID', 'lineManager'],
+            // columns use camelCase
+            [true, 'id', 'line_manager_id', 'line_manager'],
+            [true, 'ID', 'line_manager_id', 'line_manager'],
+            // foreign keys without primary key suffix
+            [false, 'id', 'lineManager', 'lineManager'],
+            [true, 'id', 'line_manager', 'line_manager'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideForeignKeyStrategyPermutations
+     *
+     * @param bool $usesSnakeAttributes
+     * @param string $primaryKey
+     * @param string $foreignKey
+     * @param string $expected
+     */
+    public function testNameUsingForeignKeyStrategy($usesSnakeAttributes, $primaryKey, $foreignKey, $expected)
+    {
+        $relation = Mockery::mock(Fluent::class)->makePartial();
+
+        $modelMock = Mockery::mock(\Reliese\Coders\Model\Model::class);
+        $relatedModel = $modelMock->makePartial();
+
+        $subject = $modelMock->makePartial();
+        $subject->shouldReceive('usesSnakeAttributes')->andReturn($usesSnakeAttributes);
+
+        /** @var BelongsTo|\Mockery\Mock $relationship */
+        $relationship = Mockery::mock(BelongsTo::class, [$relation, $subject, $relatedModel])->makePartial();
+        $relationship->shouldAllowMockingProtectedMethods();
+        $relationship->shouldReceive('otherKey')->andReturn($primaryKey);
+        $relationship->shouldReceive('foreignKey')->andReturn($foreignKey);
+
+        $this->assertEquals(
+            $expected,
+            $relationship->name(),
+            json_encode(compact('usesSnakeAttributes', 'primaryKey', 'foreignKey'))
+        );
+    }
+}

--- a/tests/Coders/Model/Relations/HasManyTest.php
+++ b/tests/Coders/Model/Relations/HasManyTest.php
@@ -13,22 +13,23 @@ class HasManyTest extends TestCase
         // usesSnakeAttributes, subjectName, relationName, primaryKey, foreignKey, expected
         return [
             // camelCase
-            [false, 'Person', 'PublishedBook', 'id', 'authorId', 'publishedBooksWhereAuthor'],
-            [false, 'Person', 'PublishedBook', 'ID', 'authorID', 'publishedBooksWhereAuthor'],
-            [false, 'Person', 'PublishedBook', 'id', 'personId', 'publishedBooks'],
-            [false, 'Person', 'PublishedBook', 'ID', 'personID', 'publishedBooks'],
+            [false, 'StaffMember', 'BlogPost', 'id', 'authorId', 'blogPostsWhereAuthor'],
+            [false, 'StaffMember', 'BlogPost', 'ID', 'authorID', 'blogPostsWhereAuthor'],
+            [false, 'StaffMember', 'BlogPost', 'id', 'staffMemberId', 'blogPosts'],
+            [false, 'StaffMember', 'BlogPost', 'ID', 'staffMemberID', 'blogPosts'],
             // snake_case
-            [true, 'Person', 'PublishedBook', 'id', 'author_id', 'published_books_where_author'],
-            [true, 'Person', 'PublishedBook', 'id', 'person_id', 'published_books'],
-            [true, 'Person', 'PublishedBook', 'ID', 'author_id', 'published_books_where_author'],
-            [true, 'Person', 'PublishedBook', 'ID', 'person_id', 'published_books'],
+            [true, 'StaffMember', 'BlogPost', 'id', 'author_id', 'blog_posts_where_author'],
+            [true, 'StaffMember', 'BlogPost', 'id', 'staff_member_id', 'blog_posts'],
+            [true, 'StaffMember', 'BlogPost', 'ID', 'author_id', 'blog_posts_where_author'],
+            [true, 'StaffMember', 'BlogPost', 'ID', 'staff_member_id', 'blog_posts'],
             // no suffix
-            [false, 'Person', 'PublishedBook', 'id', 'author', 'publishedBooksWhereAuthor'],
-            [false, 'Person', 'PublishedBook', 'id', 'person', 'publishedBooks'],
-            [true, 'Person', 'PublishedBook', 'id', 'author', 'published_books_where_author'],
-            [true, 'Person', 'PublishedBook', 'id', 'person', 'published_books'],
+            [false, 'StaffMember', 'BlogPost', 'id', 'author', 'blogPostsWhereAuthor'],
+            [false, 'StaffMember', 'BlogPost', 'id', 'staff_member', 'blogPosts'],
+            [true, 'StaffMember', 'BlogPost', 'id', 'author', 'blog_posts_where_author'],
+            [true, 'StaffMember', 'BlogPost', 'id', 'staff_member', 'blog_posts'],
             // same table reference
-            [false, 'Person', 'Person', 'id', 'lineManagerId', 'peopleWhereLineManager'],
+            [false, 'StaffMember', 'StaffMember', 'id', 'staffMemberId', 'staffMembers'],
+            [false, 'StaffMember', 'StaffMember', 'id', 'lineManagerId', 'staffMembersWhereLineManager'],
         ];
     }
 
@@ -71,10 +72,10 @@ class HasManyTest extends TestCase
     {
         // usesSnakeAttributes, subjectName, relatedName, expected
         return [
-            [false, 'Person', 'PublishedBook', 'publishedBooks'],
-            [true, 'Person', 'PublishedBook', 'published_books'],
+            [false, 'StaffMember', 'BlogPost', 'blogPosts'],
+            [true, 'StaffMember', 'BlogPost', 'blog_posts'],
             // Same table reference
-            [false, 'Person', 'Person', 'people']
+            [false, 'StaffMember', 'StaffMember', 'staffMembers']
         ];
     }
 

--- a/tests/Coders/Model/Relations/HasManyTest.php
+++ b/tests/Coders/Model/Relations/HasManyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Support\Fluent;
+use PHPUnit\Framework\TestCase;
+use Reliese\Coders\Model\Model;
+use Reliese\Coders\Model\Relations\BelongsTo;
+use Reliese\Coders\Model\Relations\HasMany;
+
+class HasManyTest extends TestCase
+{
+    public function provideForeignKeyStrategyPermutations()
+    {
+        // usesSnakeAttributes, subjectName, relationName, primaryKey, foreignKey, expected
+        return [
+            // camelCase
+            [false, 'Person', 'Book', 'id', 'authorId', 'booksWhereAuthor'],
+            [false, 'Person', 'Book', 'ID', 'authorID', 'booksWhereAuthor'],
+            [false, 'Person', 'Book', 'id', 'personId', 'books'],
+            [false, 'Person', 'Book', 'ID', 'personID', 'books'],
+            // snake_case
+            [true, 'Person', 'Book', 'id', 'author_id', 'books_where_author'],
+            [true, 'Person', 'Book', 'id', 'person_id', 'books'],
+            [true, 'Person', 'Book', 'ID', 'author_id', 'books_where_author'],
+            [true, 'Person', 'Book', 'ID', 'person_id', 'books'],
+            // no suffix
+            [false, 'Person', 'Book', 'id', 'author', 'booksWhereAuthor'],
+            [false, 'Person', 'Book', 'id', 'person', 'books'],
+            [true, 'Person', 'Book', 'id', 'author', 'books_where_author'],
+            [true, 'Person', 'Book', 'id', 'person', 'books'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideForeignKeyStrategyPermutations
+     *
+     * @param bool $usesSnakeAttributes
+     * @param string $subjectName
+     * @param string $relationName
+     * @param string $primaryKey
+     * @param string $foreignKey
+     * @param string $expected
+     */
+    public function testNameUsingForeignKeyStrategy($usesSnakeAttributes, $subjectName, $relationName, $primaryKey, $foreignKey, $expected)
+    {
+        $relation = Mockery::mock(Fluent::class)->makePartial();
+
+        $relatedModel = Mockery::mock(Model::class)->makePartial();
+        $relatedModel->shouldReceive('getClassName')->andReturn($relationName);
+
+        $subject = Mockery::mock(Model::class)->makePartial();
+        $subject->shouldReceive('getRelationNameStrategy')->andReturn('foreign_key');
+        $subject->shouldReceive('usesSnakeAttributes')->andReturn($usesSnakeAttributes);
+        $subject->shouldReceive('getClassName')->andReturn($subjectName);
+
+        /** @var BelongsTo|\Mockery\Mock $relationship */
+        $relationship = Mockery::mock(HasMany::class, [$relation, $subject, $relatedModel])->makePartial();
+        $relationship->shouldAllowMockingProtectedMethods();
+        $relationship->shouldReceive('localKey')->andReturn($primaryKey);
+        $relationship->shouldReceive('foreignKey')->andReturn($foreignKey);
+
+        $this->assertEquals(
+            $expected,
+            $relationship->name(),
+            json_encode(compact('usesSnakeAttributes', 'subjectName', 'relationName', 'primaryKey', 'foreignKey'))
+        );
+    }
+}

--- a/tests/Coders/Model/Relations/RelationHelperTest.php
+++ b/tests/Coders/Model/Relations/RelationHelperTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Reliese\Coders\Model\Relations\RelationHelper;
+
+class RelationHelperTest extends TestCase
+{
+    public function provideKeys()
+    {
+        // usesSnakeAttributes, primaryKey, foreignKey, expected
+        return [
+            // camelCase
+            [false, 'id', 'lineManagerId', 'lineManager'],
+            [false, 'ID', 'lineManagerID', 'lineManager'],
+            // snake_case
+            [true, 'id', 'line_manager_id', 'line_manager'],
+            [true, 'ID', 'line_manager_id', 'line_manager'],
+            // no suffix
+            [false, 'id', 'lineManager', 'lineManager'],
+            [true, 'id', 'line_manager', 'line_manager'],
+            // columns that contain the letters of the primary key as part of their name
+            [false, 'id', 'holiday', 'holiday'],
+            [true, 'id', 'something_identifier_id', 'something_identifier']
+        ];
+    }
+
+    /**
+     * @dataProvider provideKeys
+     *
+     * @param bool $usesSnakeAttributes
+     * @param string $primaryKey
+     * @param string $foreignKey
+     * @param string $expected
+     */
+    public function testNameUsingForeignKeyStrategy($usesSnakeAttributes, $primaryKey, $foreignKey, $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            RelationHelper::stripSuffixFromForeignKey($usesSnakeAttributes, $primaryKey, $foreignKey),
+            json_encode(compact('usesSnakeAttributes', 'primaryKey', 'foreignKey'))
+        );
+    }
+}


### PR DESCRIPTION
Fixes #176 

Hi @CristianLlanos, here are the updates to the foreign_key naming strategy that we discussed in #176. Hopefully the unit tests give a good overview of the situations that it is designed to handle.

I've ran this against a large existing code base and the generated relationship names are a huge improvement, as well as generating many additional relationships that weren't previously possible due to naming collisions.

Do let me know if you require any changes or have any questions.