### PR TITLE
Provide facility to manually override generated model names

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -323,6 +323,26 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Model Names
+        |--------------------------------------------------------------------------
+        |
+        | By default the generator will create models with names that match your tables.
+        | However, if you wish to manually override the naming, you can specify a mapping
+        | here between table and model names.
+        |
+        | Example:
+        |   A table called 'billing_invoices' will generate a model called `BillingInvoice`,
+        |   but you'd prefer it to generate a model called 'Invoice'. Therefore, you'd add
+        |   the following array key and value:
+        |     'billing_invoices' => 'Invoice',
+        */
+
+        'model_names' => [
+
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
         | Relation Name Strategy
         |--------------------------------------------------------------------------
         |

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -521,7 +521,7 @@ class Model
      */
     public function getClassName()
     {
-        // Model names can be manually configured by users in the config file.
+        // Model names can be manually overridden by users in the config file.
         // If a config entry exists for this table, use that name, rather than generating one.
         $overriddenName = $this->config('model_names.' . $this->getTable());
         if ($overriddenName) {

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -521,6 +521,13 @@ class Model
      */
     public function getClassName()
     {
+        // Model names can be manually configured by users in the config file.
+        // If a config entry exists for this table, use that name, rather than generating one.
+        $overriddenName = $this->config('model_names.' . $this->getTable());
+        if ($overriddenName) {
+            return $overriddenName;
+        }
+
         if ($this->shouldLowerCaseTableName()) {
             return Str::studly(Str::lower($this->getRecordName()));
         }


### PR DESCRIPTION
In situations where a table name is not suitable as a model name, this feature gives users the facility to override these generated model names.

A common real-world practice is to name tables in a way that visually groups tables that have similar functionality when they are sorted alphabetically:
```
employees
employees_preferences
```
However, by default this would generate the model `EmployeesPreference`, when really we want a model called `EmployeePreference`.

Another common practice is to give all tables in a particular module the same prefix, to achieve the same visual grouping:
```
billing_invoices
billing_payments
```
However, the prefix might be unnecessary in the model, and we may just want a model called `Invoice` and `Payment`.

This change adds a simple array mapping between table and model names to override the default naming in these instances.