### PR TITLE
Expand Blueprint into DatabaseBlueprint, SchemaBlueprint, and TableBlueprint

### DIFF
--- a/src/Blueprint/BlueprintFactory.php
+++ b/src/Blueprint/BlueprintFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Reliese\Blueprint;
+
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\SQLiteConnection;
+use Reliese\Coders\Model\Config;
+
+use Reliese\Meta\AdapterFactory;
+use Reliese\Meta\DatabaseInterface;
+use Reliese\Meta\MySql\Database as MySqlDatabase;
+use Reliese\Meta\Postgres\Database as PostgresDatabase;
+use Reliese\Meta\Sqlite\Database as SqliteDatabase;
+
+use function get_class;
+
+/**
+ * Class DatabaseFactory
+ */
+class BlueprintFactory
+{
+    /**
+     * @var DatabaseBlueprint
+     */
+    private $laravelDatabaseManager;
+
+    /**
+     * @var DatabaseBlueprint[]
+     */
+    private $databaseBlueprints = [];
+
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var AdapterFactory
+     */
+    private $adapterFactory;
+
+    /**
+     * BlueprintFactory constructor.
+     * @param DatabaseManager $databaseManager
+     * @param AdapterFactory $adapterFactory
+     * @param Config $config
+     */
+    public function __construct(
+        $adapterFactory,
+        $databaseManager,
+        $config
+    ) {
+        $this->laravelDatabaseManager = $databaseManager;
+        $this->config = $config;
+        $this->adapterFactory = $adapterFactory;
+    }
+
+    /**
+     * @param $connectionName
+     * @return DatabaseBlueprint
+     */
+    public function database($connectionName)
+    {
+        if (!empty($this->databaseBlueprints[$connectionName])) {
+            return $this->databaseBlueprints[$connectionName];
+        }
+
+        $connection = $this->laravelDatabaseManager->connection($connectionName);
+
+        $databaseBlueprint = new DatabaseBlueprint(
+            $this->adapterFactory->database($connection),
+            $connectionName,
+            $connection
+        );
+
+        return $this->databaseBlueprints[$connectionName] = $databaseBlueprint;
+    }
+}

--- a/src/Blueprint/DatabaseBlueprint.php
+++ b/src/Blueprint/DatabaseBlueprint.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Reliese\Blueprint;
+
+use Reliese\Meta\DatabaseInterface;
+use RuntimeException;
+
+/**
+ * Class DatabaseManager
+ */
+class DatabaseBlueprint
+{
+    /**
+     * The name of the connection from the Laravel config/database.php file
+     *
+     * @var string
+     */
+    private $connectionName;
+
+    /**
+     * @var \Illuminate\Database\Connection
+     */
+    private $connection;
+
+    /**
+     * @var SchemaBlueprint[]
+     */
+    private $schemaBlueprints;
+    /**
+     * @var DatabaseInterface
+     */
+    private $databaseAdapter;
+
+    /**
+     * DatabaseBlueprint constructor.
+     * @param DatabaseInterface $databaseAdapter
+     * @param string $connectionName
+     * @param \Illuminate\Database\Connection $connection
+     */
+    public function __construct(
+        $databaseAdapter,
+        $connectionName,
+        $connection
+    ) {
+        $this->connectionName = $connectionName;
+        $this->connection = $connection;
+        $this->databaseAdapter = $databaseAdapter;
+    }
+
+    /**
+     * If a schema name is not provided, then the default schema for the connection will be used
+     * @param string|null $schemaName
+     * @return SchemaBlueprint
+     */
+    public function schema($schemaName)
+    {
+        if (!empty($this->schemaBlueprints[$schemaName])) {
+            return $this->schemaBlueprints[$schemaName];
+        }
+
+        return $this->schemaBlueprints[$schemaName] = new SchemaBlueprint(
+            $this,
+            $this->databaseAdapter->getSchema($schemaName),
+            $schemaName
+        );
+    }
+
+    # region Accessors
+    /**
+     * @return \Illuminate\Database\Connection
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+    # endregion Accessors
+}

--- a/src/Blueprint/SchemaBlueprint.php
+++ b/src/Blueprint/SchemaBlueprint.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Reliese\Blueprint;
+
+use Reliese\Meta\Schema;
+use Reliese\Meta\SchemaManager;
+
+use function get_class;
+
+/**
+ * Class SchemaBlueprint
+ */
+class SchemaBlueprint
+{
+    /**
+     * @var
+     */
+    private $schemaName;
+
+    /**
+     * @var
+     */
+    private $databaseBlueprint;
+
+    /**
+     * @var TableBlueprint[]
+     */
+    private $tableBlueprints;
+
+    /**
+     * @deprecated The SchemaBlueprint class should replace usage of SchemaManager. To maintain backwards compatibility,
+     * SchemaBlueprint wraps SchemaManager
+     *
+     * @var SchemaManager
+     */
+    private $schemaManager;
+    /**
+     * @var Schema
+     */
+    private $schemaAdapter;
+
+    /**
+     * SchemaBlueprint constructor.
+     * @param Schema $schemaAdapter
+     * @param string $schemaName
+     * @param DatabaseBlueprint $databaseBlueprint
+     */
+    public function __construct(
+        $databaseBlueprint,
+        Schema $schemaAdapter,
+        $schemaName
+    ) {
+        $this->schemaAdapter = $schemaAdapter;
+        $this->schemaName = $schemaName;
+        $this->databaseBlueprint = $databaseBlueprint;
+
+        $this->schemaManager = new SchemaManager(
+            $databaseBlueprint->getConnection()
+        );
+    }
+
+    public function table($tableName)
+    {
+        if (!empty($this->tableBlueprints[$tableName])) {
+            return $this->tableBlueprints[$tableName];
+        }
+
+        $blueprint = $this->schemaAdapter->table($tableName);
+
+        return $this->tableBlueprints[$tableName] = new TableBlueprint(
+            $this,
+            $tableName,
+            $blueprint
+        );
+    }
+
+    public function schemaAdapter()
+    {
+
+    }
+
+    # region Accessors
+
+    # endregion Accessors
+}

--- a/src/Blueprint/TableBlueprint.php
+++ b/src/Blueprint/TableBlueprint.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Reliese\Blueprint;
+
+use Reliese\Meta\Blueprint as DeprecatedTableBlueprint;
+
+/**
+ * Class TableBlueprint
+ */
+class TableBlueprint
+{
+    /**
+     * @var string
+     */
+    private $tableName;
+
+    /**
+     * @var SchemaBlueprint
+     */
+    private $schemaBlueprint;
+    /**
+     * @var DeprecatedTableBlueprint
+     */
+    private $deprecatedTableBlueprint;
+
+    /**
+     * TableBlueprint constructor.
+     * @param $tableName
+     * @param SchemaBlueprint $schemaBlueprint
+     */
+    public function __construct(
+        SchemaBlueprint $schemaBlueprint,
+        $tableName,
+        DeprecatedTableBlueprint $depricatedTableBlueprint
+    ) {
+        $this->tableName = $tableName;
+        $this->schemaBlueprint = $schemaBlueprint;
+        $this->deprecatedTableBlueprint = $depricatedTableBlueprint;
+    }
+}

--- a/src/Meta/AdapterFactory.php
+++ b/src/Meta/AdapterFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Reliese\Meta;
+
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\SQLiteConnection;
+use Reliese\Meta\MySql\Database as MySqlDatabase;
+use Reliese\Meta\Postgres\Database as PostgresDatabase;
+use Reliese\Meta\Sqlite\Database as SqliteDatabase;
+use Reliese\Meta\MySql\Schema as MySqlSchema;
+use Reliese\Meta\Postgres\Schema as PostgresSchema;
+use Reliese\Meta\Sqlite\Schema as SqliteSchema;
+
+use function get_class;
+
+/**
+ * Class AdapterFactory
+ */
+class AdapterFactory
+{
+    /**
+     * @param \Illuminate\Database\Connection $connection
+     * @return DatabaseInterface
+     */
+    public function database($connection)
+    {
+        switch (get_class($connection)) {
+            case \Larapack\DoctrineSupport\Connections\MySqlConnection::class:
+            case MySqlConnection::class:
+                /** @noinspection PhpParamsInspection */
+                return new MySqlDatabase($connection);
+            case SQLiteConnection::class:
+                /** @noinspection PhpParamsInspection */
+                return new SqliteDatabase($connection);
+            case PostgresConnection::class:
+                /** @noinspection PhpParamsInspection */
+                return new PostgresDatabase($connection);
+        }
+
+        throw new \RuntimeException(__METHOD__." does not define an implementation for ".DatabaseInterface::class);
+    }
+}

--- a/src/Meta/DatabaseInterface.php
+++ b/src/Meta/DatabaseInterface.php
@@ -2,6 +2,8 @@
 
 namespace Reliese\Meta;
 
+use Reliese\Meta\MySql\Schema;
+
 /**
  * Interface DatabaseInterface
  */
@@ -13,4 +15,10 @@ interface DatabaseInterface
      * @return string[]
      */
     public function getSchemaNames();
+
+    /**
+     * @param string $schemaName
+     * @return Schema
+     */
+    public function getSchema($schemaName);
 }

--- a/src/Meta/DatabaseInterface.php
+++ b/src/Meta/DatabaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Reliese\Meta;
+
+/**
+ * Interface DatabaseInterface
+ */
+interface DatabaseInterface
+{
+    /**
+     * Returns an array of accessible schema names
+     *
+     * @return string[]
+     */
+    public function getSchemaNames();
+}

--- a/src/Meta/MySql/Database.php
+++ b/src/Meta/MySql/Database.php
@@ -12,11 +12,20 @@ use function array_diff;
 class Database implements DatabaseInterface
 {
     /**
-     * @var \Illuminate\Database\Connection
+     * @var Schema[]
+     */
+    private $schemaAdapters = [];
+
+    /**
+     * @var \Illuminate\Database\MySqlConnection
      */
     private $connection;
 
-    public function __construct(\Illuminate\Database\Connection $connection)
+    /**
+     * Database constructor.
+     * @param \Illuminate\Database\MySqlConnection $connection
+     */
+    public function __construct(\Illuminate\Database\MySqlConnection $connection)
     {
         $this->connection = $connection;
     }
@@ -34,5 +43,17 @@ class Database implements DatabaseInterface
             'mysql',
             'performance_schema',
         ]);
+    }
+
+    /**
+     * @param string $schemaName
+     * @return Schema
+     */
+    public function getSchema($schemaName)
+    {
+        if (!empty($this->schemaAdapters[$schemaName])) {
+            return $this->schemaAdapters[$schemaName];
+        }
+        return $this->schemaAdapters[$schemaName] = new Schema($schemaName, $this->connection);
     }
 }

--- a/src/Meta/MySql/Database.php
+++ b/src/Meta/MySql/Database.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Reliese\Meta\MySql;
+
+use function array_diff;
+
+/**
+ * Class Database
+ */
+class Database
+{
+    /**
+     * @var \Illuminate\Database\Connection
+     */
+    private $connection;
+
+    public function __construct(\Illuminate\Database\Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSchemaNames()
+    {
+        $schemas = $this->connection->getDoctrineSchemaManager()->listDatabases();
+
+        return array_diff($schemas, [
+            'information_schema',
+            'sys',
+            'mysql',
+            'performance_schema',
+        ]);
+    }
+}

--- a/src/Meta/MySql/Database.php
+++ b/src/Meta/MySql/Database.php
@@ -2,12 +2,14 @@
 
 namespace Reliese\Meta\MySql;
 
+use Reliese\Meta\DatabaseInterface;
+
 use function array_diff;
 
 /**
  * Class Database
  */
-class Database
+class Database implements DatabaseInterface
 {
     /**
      * @var \Illuminate\Database\Connection

--- a/src/Meta/MySql/Schema.php
+++ b/src/Meta/MySql/Schema.php
@@ -265,19 +265,12 @@ class Schema implements \Reliese\Meta\Schema
 
     /**
      * @param \Illuminate\Database\Connection $connection
-     *
+     * @deprecated use \Reliese\Meta\MySql\Database::getSchemaNames instead
      * @return array
      */
     public static function schemas(Connection $connection)
     {
-        $schemas = $connection->getDoctrineSchemaManager()->listDatabases();
-
-        return array_diff($schemas, [
-            'information_schema',
-            'sys',
-            'mysql',
-            'performance_schema',
-        ]);
+        return (new Database($connection))->getSchemaNames();
     }
 
     /**

--- a/src/Meta/Postgres/Database.php
+++ b/src/Meta/Postgres/Database.php
@@ -12,11 +12,20 @@ use function array_diff;
 class Database implements DatabaseInterface
 {
     /**
-     * @var \Illuminate\Database\Connection
+     * @var Schema[]
+     */
+    private $schemaAdapters = [];
+
+    /**
+     * @var \Illuminate\Database\PostgresConnection
      */
     private $connection;
 
-    public function __construct(\Illuminate\Database\Connection $connection)
+    /**
+     * Database constructor.
+     * @param \Illuminate\Database\PostgresConnection $connection
+     */
+    public function __construct(\Illuminate\Database\PostgresConnection $connection)
     {
         $this->connection = $connection;
     }
@@ -33,5 +42,17 @@ class Database implements DatabaseInterface
             'template0',
             'template1',
         ]);
+    }
+
+    /**
+     * @param string $schemaName
+     * @return Schema
+     */
+    public function getSchema($schemaName)
+    {
+        if (!empty($this->schemaAdapters[$schemaName])) {
+            return $this->schemaAdapters[$schemaName];
+        }
+        return $this->schemaAdapters[$schemaName] = new Schema($schemaName, $this->connection);
     }
 }

--- a/src/Meta/Postgres/Database.php
+++ b/src/Meta/Postgres/Database.php
@@ -2,12 +2,14 @@
 
 namespace Reliese\Meta\Postgres;
 
+use Reliese\Meta\DatabaseInterface;
+
 use function array_diff;
 
 /**
  * Class Database
  */
-class Database
+class Database implements DatabaseInterface
 {
     /**
      * @var \Illuminate\Database\Connection

--- a/src/Meta/Postgres/Database.php
+++ b/src/Meta/Postgres/Database.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Reliese\Meta\Postgres;
+
+use function array_diff;
+
+/**
+ * Class Database
+ */
+class Database
+{
+    /**
+     * @var \Illuminate\Database\Connection
+     */
+    private $connection;
+
+    public function __construct(\Illuminate\Database\Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSchemaNames()
+    {
+        $schemas = $this->connection->getDoctrineSchemaManager()->listDatabases();
+
+        return array_diff($schemas, [
+            'postgres',
+            'template0',
+            'template1',
+        ]);
+    }
+}

--- a/src/Meta/Postgres/Schema.php
+++ b/src/Meta/Postgres/Schema.php
@@ -268,18 +268,12 @@ class Schema implements \Reliese\Meta\Schema
 
     /**
      * @param \Illuminate\Database\Connection $connection
-     *
+     * @deprecated use \Reliese\Meta\Postgres\Database::getSchemaNames
      * @return array
      */
     public static function schemas(Connection $connection)
     {
-        $schemas = $connection->getDoctrineSchemaManager()->listDatabases();
-
-        return array_diff($schemas, [
-            'postgres',
-            'template0',
-            'template1',
-        ]);
+        return (new Database($connection))->getSchemaNames();
     }
 
     /**

--- a/src/Meta/Sqlite/Database.php
+++ b/src/Meta/Sqlite/Database.php
@@ -2,10 +2,12 @@
 
 namespace Reliese\Meta\Sqlite;
 
+use Reliese\Meta\DatabaseInterface;
+
 /**
  * Class Database
  */
-class Database
+class Database implements DatabaseInterface
 {
     /**
      * @var \Illuminate\Database\Connection

--- a/src/Meta/Sqlite/Database.php
+++ b/src/Meta/Sqlite/Database.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Reliese\Meta\Sqlite;
+
+/**
+ * Class Database
+ */
+class Database
+{
+    /**
+     * @var \Illuminate\Database\Connection
+     */
+    private $connection;
+
+    public function __construct(\Illuminate\Database\Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSchemaNames()
+    {
+        return ['database'];
+    }
+}

--- a/src/Meta/Sqlite/Database.php
+++ b/src/Meta/Sqlite/Database.php
@@ -10,11 +10,20 @@ use Reliese\Meta\DatabaseInterface;
 class Database implements DatabaseInterface
 {
     /**
-     * @var \Illuminate\Database\Connection
+     * @var Schema[]
+     */
+    private $schemaAdapters = [];
+
+    /**
+     * @var \Illuminate\Database\SQLiteConnection
      */
     private $connection;
 
-    public function __construct(\Illuminate\Database\Connection $connection)
+    /**
+     * Database constructor.
+     * @param \Illuminate\Database\SQLiteConnection $connection
+     */
+    public function __construct(\Illuminate\Database\SQLiteConnection $connection)
     {
         $this->connection = $connection;
     }
@@ -25,5 +34,17 @@ class Database implements DatabaseInterface
     public function getSchemaNames()
     {
         return ['database'];
+    }
+
+    /**
+     * @param string $schemaName
+     * @return Schema
+     */
+    public function getSchema($schemaName)
+    {
+        if (!empty($this->schemaAdapters[$schemaName])) {
+            return $this->schemaAdapters[$schemaName];
+        }
+        return $this->schemaAdapters[$schemaName] = new Schema($schemaName, $this->connection);
     }
 }

--- a/src/Meta/Sqlite/Schema.php
+++ b/src/Meta/Sqlite/Schema.php
@@ -194,12 +194,12 @@ class Schema implements \Reliese\Meta\Schema
 
     /**
      * @param \Illuminate\Database\Connection $connection
-     *
+     * @deprecated use \Reliese\Meta\Sqlite\Database::getSchemaNames
      * @return array
      */
     public static function schemas(Connection $connection)
     {
-        return ['database'];
+        return (new Database($connection))->getSchemaNames();
     }
 
     /**

--- a/src/Meta/Sqlite/Schema.php
+++ b/src/Meta/Sqlite/Schema.php
@@ -36,7 +36,7 @@ class Schema implements \Reliese\Meta\Schema
      * Mapper constructor.
      *
      * @param string $schema
-     * @param \Illuminate\Database\MySqlConnection $connection
+     * @param \Illuminate\Database\SQLiteConnection $connection
      */
     public function __construct($schema, $connection)
     {


### PR DESCRIPTION
These changes extend the work that was done in [https://github.com/reliese/laravel/pull/200/files](https://github.com/reliese/laravel/pull/200/files)

The new classes define a (hopefully) "idealized" representation of meta data from a database.

In the case of SchemaBlueprint it is a wrapper around a the existing Schema implementations.

The reason it is implemented as a "wrapper" is to ensure that previous implementations can be "adapted" to fit a new object model that organizes blueprints as a hierarchy of blueprints.

intended usage:
```php
    public function handle()
    {
        $connection = $this->getConnection();
        $schema = $this->getSchema($connection);
        $table = $this->getTable();

        $schemaBlueprint = $this->blueprintFactory->database($connection)->schema($schema);

        $tableBlueprints = [];
        // Check whether we just need to generate one table
        if ($table) {
            $tableBlueprints[] = $schemaBlueprint->table($table);
        } else {
            $tableBlueprints = $schemaBlueprint->allTables($table);
        }
        
        /* TODO: allow command options to override the blueprint definition */

        // convert Blueprints into Model definitions
        $modelManager = new ModelManager($config);
        foreach ($tableBlueprints as $tableBlueprint) {
            $model = $this->modelFactory->fromTableBlueprint($tableBlueprint);
            $modelManager->addModel($model);
        }
        
        $modelManager->generateModelFiles();
        
    }
```
