### PR TITLE
Tweak to only skip shortening namespace when using base files

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -324,7 +324,7 @@ class Factory
                  *
                  * @see https://github.com/reliese/laravel/issues/209
                  */
-                if ($usedClass === $model->getQualifiedUserClassName()) {
+                if ($model->usesBaseFiles() && $usedClass === $model->getQualifiedUserClassName()) {
                     continue;
                 }
 


### PR DESCRIPTION
This optimises the output slightly when not using base files.