### PR TITLE
Added support for grimzy/laravel-mysql-spatial

### DIFF
--- a/src/Meta/SchemaManager.php
+++ b/src/Meta/SchemaManager.php
@@ -28,6 +28,7 @@ class SchemaManager implements IteratorAggregate
         SQLiteConnection::class => SqliteSchema::class,
         PostgresConnection::class => PostgresSchema::class,
         \Larapack\DoctrineSupport\Connections\MySqlConnection::class => MySqlSchema::class,
+        \Grimzy\LaravelMysqlSpatial\MysqlConnection::class => MySqlSchema::class,
     ];
 
     /**


### PR DESCRIPTION
Grimzy\LaravelMysqlSpatial\MysqlConnection extends Illuminate\Database\MySqlConnection but doesn't work due to hasMapping() check