### PR TITLE
Update PostgreSQL Driver

### DIFF
--- a/src/Meta/Postgres/Column.php
+++ b/src/Meta/Postgres/Column.php
@@ -194,7 +194,9 @@ class Column implements \Reliese\Meta\Column
     private function defaultIsNextVal(Fluent $attributes)
     {
         $value = $this->get('column_default', $this->get('generation_expression', null));
+        $isIdentity = $this->get('is_identity');
+        $identityGeneration =  $this->get('identity_generation');
 
-        return preg_match('/nextval\(/i', $value);
+        return preg_match('/nextval\(/i', $value) || ($isIdentity === 'YES' && $identityGeneration === 'BY DEFAULT');
     }
 }

--- a/src/Meta/Postgres/Column.php
+++ b/src/Meta/Postgres/Column.php
@@ -28,12 +28,12 @@ class Column implements \Reliese\Meta\Column
      * @todo check these
      */
     public static $mappings = [
-        'string' => ['varchar', 'text', 'string', 'char', 'enum', 'tinytext', 'mediumtext', 'longtext', 'json'],
-        'date' => ['datetime', 'year', 'date', 'time', 'timestamp'],
-        'int' => ['int', 'integer', 'tinyint', 'smallint', 'mediumint', 'bigint', 'bigserial', 'serial', 'smallserial', 'tinyserial', 'serial4', 'serial8'],
-        'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
-        'boolean' => ['boolean', 'bool', 'bit'],
-        'binary' => ['blob', 'longblob', 'jsonb'],
+      'string' => ['character varying', 'varchar', 'text', 'string', 'char', 'character','enum', 'tinytext', 'mediumtext', 'longtext', 'json'],
+      'date' => ['timestamp with time zone', 'timestamp without time zone', 'timestamptz', 'datetime', 'year', 'date', 'time', 'timestamp'],
+      'int' => ['int', 'integer', 'tinyint', 'smallint', 'mediumint', 'bigint', 'bigserial', 'serial', 'smallserial', 'tinyserial', 'serial4', 'serial8'],
+      'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
+      'boolean' => ['boolean', 'bool', 'bit'],
+      'binary' => ['blob', 'longblob', 'jsonb'],
     ];
 
     /**


### PR DESCRIPTION
solves type and new column type problems since postgres >10 identity

postgresql 9.x is in EOL (November 11, 2021) [those who need SERIAL stay on postgresql 9.x]

SQL code created by knex.js migrations:
```sql
create table company (
  id integer generated by default as identity constraint company_pkey primary key, 
  legacy_organization_id integer generated by default as identity constraint company_organization_id_unique unique, 
  name varchar(255) not null constraint company_name_unique unique, 
  ...
  ...
  created_at timestamp with time zone default CURRENT_TIMESTAMP not null, 
  updated_at timestamp with time zone default CURRENT_TIMESTAMP not null
);
```

Particularly this solves my problem, I already tried it, but I don't know if there are more types that other people use, or if there is any other option in the identity columns than the default one (I only used that one).

![image](https://user-images.githubusercontent.com/18271791/124187175-0a1a5180-da83-11eb-8fbd-d2aa3f640b9c.png)

