### PR TITLE
fix deprecation warning for at least php 8.1.6

### DIFF
--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -502,7 +502,12 @@ class Model
      */
     public function withParentClass($parent)
     {
-        $this->parentClass = '\\' . ltrim($parent, '\\');
+        $thisParentClass = '\\';
+        if (! is_null($parent)) {
+            $thisParentClass =  $thisParentClass . ltrim($parent, '\\');
+        }
+
+        $this->parentClass = $thisParentClass;
 
         return $this;
     }


### PR DESCRIPTION
running `vendor/bin/phpunit` on at least php version 8.1.6 results in multiple
warnings that state:

Deprecated: ltrim(): Passing null to parameter #1 ($string) of type string is deprecated in .../Coders/Model/Model.php on line 505

add a conditional to check the argument for null before using it to build parentClass