### PR TITLE
Add few tables on the except array, Fix some typo errors

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -161,7 +161,7 @@ return [
         | Base Files
         |--------------------------------------------------------------------------
         |
-        | By default, your models will be generated in your models' path, but
+        | By default, your models will be generated in your models path, but
         | when you generate them again they will be replaced by new ones.
         | You may want to customize your models and, at the same time, be
         | able to generate them as your tables change. For that, you
@@ -254,7 +254,7 @@ return [
         |--------------------------------------------------------------------------
         |
         | You may want to specify which of your table fields should be cast as
-        | something different from a string. For instance, you may want a
+        | something other than a string. For instance, you may want a
         | text field be cast as an array or and object.
         |
         | You may define column patterns which will be cast using the value
@@ -284,13 +284,7 @@ return [
             'failed_jobs',
             'password_resets',
             'personal_access_tokens',
-            'notifications',
-            'nova_field_attachments',
-            'nova_notifications',
-            'nova_pending_field_attachments',
-            'telescope_entries',
-            'telescope_entries_tags',
-            'telescope_monitoring',
+            'password_reset_tokens',
         ],
 
         /*

--- a/config/models.php
+++ b/config/models.php
@@ -161,7 +161,7 @@ return [
         | Base Files
         |--------------------------------------------------------------------------
         |
-        | By default, your models will be generated in your models path, but
+        | By default, your models will be generated in your models' path, but
         | when you generate them again they will be replaced by new ones.
         | You may want to customize your models and, at the same time, be
         | able to generate them as your tables change. For that, you
@@ -211,7 +211,7 @@ return [
         | TRUE: Schema name will be prepended on the table
         | FALSE:Table name will be set without schema name.
         | NULL: Table name will follow laravel pattern,
-        |   i.e if class name(plural) matches table name, then table name will not be added
+        |   i.e. if class name(plural) matches table name, then table name will not be added
         */
 
         'qualified_tables' => false,
@@ -253,11 +253,11 @@ return [
         | Casts
         |--------------------------------------------------------------------------
         |
-        | You may want to specify which of your table fields should be casted as
-        | something different than a string. For instance, you may want a
-        | text field be casted as an array or and object.
+        | You may want to specify which of your table fields should be cast as
+        | something different from a string. For instance, you may want a
+        | text field be cast as an array or and object.
         |
-        | You may define column patterns which will be casted using the value
+        | You may define column patterns which will be cast using the value
         | assigned. We have defined some fields for you. Feel free to
         | modify them to fit your needs.
         |
@@ -281,6 +281,16 @@ return [
 
         'except' => [
             'migrations',
+            'failed_jobs',
+            'password_resets',
+            'personal_access_tokens',
+            'notifications',
+            'nova_field_attachments',
+            'nova_notifications',
+            'nova_pending_field_attachments',
+            'telescope_entries',
+            'telescope_entries_tags',
+            'telescope_monitoring',
         ],
 
         /*
@@ -416,7 +426,7 @@ return [
         |--------------------------------------------------------------------------
         | Move $fillable property to base files
         |--------------------------------------------------------------------------
-        | When base_files is true you can set fillable_in_base_files to true 
+        | When base_files is true you can set fillable_in_base_files to true
         | if you want the $fillable to be generated in base files
         |
         */


### PR DESCRIPTION
Update the except array to exclude Telescope and Laravel Nova tables by default and fix som typography errors remarked by PHPStorm.