### PR TITLE
Remove deprecated $dates cast

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -459,10 +459,6 @@ class Factory
             $body .= $this->class->field('casts', $model->getCasts(), ['before' => "\n"]);
         }
 
-        if ($model->hasDates()) {
-            $body .= $this->class->field('dates', $model->getDates(), ['before' => "\n"]);
-        }
-
         if ($model->hasHidden() && $model->doesNotUseBaseFiles()) {
             $body .= $this->class->field('hidden', $model->getHidden(), ['before' => "\n"]);
         }

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -70,11 +70,6 @@ class Model
     /**
      * @var array
      */
-    protected $dates = [];
-
-    /**
-     * @var array
-     */
     protected $hints = [];
 
     /**
@@ -267,12 +262,8 @@ class Model
             $cast = 'string';
         }
 
-        // Track dates
-        if ($cast == 'date') {
-            $this->dates[] = $propertyName;
-        }
-        // Track attribute casts
-        elseif ($cast != 'string') {
+        // Track attribute casts, ignoring timestamps
+        if ($cast != 'string' && !in_array($propertyName, [$this->CREATED_AT, $this->UPDATED_AT])) {
             $this->casts[$propertyName] = $cast;
         }
 
@@ -1001,7 +992,12 @@ class Model
      */
     public function getDates()
     {
-        return array_diff($this->dates, [$this->CREATED_AT, $this->UPDATED_AT]);
+        return array_diff(
+            array_filter($this->casts, function (string $cast) {
+                return $cast === 'date';
+            }),
+            [$this->CREATED_AT, $this->UPDATED_AT]
+        );
     }
 
     /**


### PR DESCRIPTION
In Laravel 8 the `$dates` cast was deprecated in favor of using the exitinsg $casts property - in Laravel 10 it is removed entirely. This PR removes the deprecated property and moves date casting to the existing `$casts` array.

Here is how the change looks:
```diff
class User extends Model 
{
    protected $casts = [
        'isAdmin' => 'boolean',
+       'lastLogin' => 'date'
    ];

-    protected $dates = [
-        'lastLogin'
-    ];
}
```

This approach of handling date casts is [supported as far back as Laravel 5.1](https://laravel.com/docs/5.1/eloquent-mutators#attribute-casting) so there should be no compatability issues with existing codebases. The only breaking change here is for people who directly accessed the `$dates` property for whatever reason. If you still need access to only date casts, then the following method can be added to return the same data that would have been held in the property.

```php
public function dates()
{
    return array_keys(array_filter($this->casts, function (string $cast) {
        return $cast === 'date';
    }));
}
```

Fixes #234 