### PR TITLE
Table namespaces

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -493,6 +493,17 @@ class Factory
     }
 
     /**
+     * @param string $table
+     * @return array
+     */
+    protected function namespaces($table)
+    {
+        return collect(explode('__', $table))->slice(0, -1)->map(function ($particle) {
+            return Str::studly($particle);
+        })->all();
+    }
+
+    /**
      * @param \Reliese\Coders\Model\Model $model
      * @param array $custom
      *
@@ -500,7 +511,9 @@ class Factory
      */
     protected function modelPath(Model $model, $custom = [])
     {
-        $modelsDirectory = $this->path(array_merge([$this->config($model->getBlueprint(), 'path')], $custom));
+        $namespaces = $this->namespaces($model->getTable());
+
+        $modelsDirectory = $this->path(array_merge([$this->config($model->getBlueprint(), 'path')], $namespaces, $custom));
 
         if (! $this->files->isDirectory($modelsDirectory)) {
             $this->files->makeDirectory($modelsDirectory, 0755, true);

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -455,13 +455,11 @@ class Model
      */
     public function withNamespace($namespace)
     {
-        $tableNamespaces = collect(
+        $this->namespace = collect(
             explode('__', $this->blueprint->table())
         )->slice(0, -1)->map(function ($particle) {
             return Str::studly($particle);
-        })->join('\\');
-
-        $this->namespace = $namespace . '\\' . $tableNamespaces;
+        })->prepend($namespace)->join('\\');
 
         return $this;
     }

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -455,7 +455,13 @@ class Model
      */
     public function withNamespace($namespace)
     {
-        $this->namespace = $namespace;
+        $tableNamespaces = collect(
+            explode('__', $this->blueprint->table())
+        )->slice(0, -1)->map(function ($particle) {
+            return Str::studly($particle);
+        })->join('\\');
+
+        $this->namespace = $namespace . '\\' . $tableNamespaces;
 
         return $this;
     }
@@ -754,9 +760,20 @@ class Model
 
     /**
      * @param string $table
+     * @return string
+     */
+    public function removeTableNamespaces($table)
+    {
+        return collect(explode('__', $table))->last();
+    }
+
+    /**
+     * @param string $table
      */
     public function removeTablePrefix($table)
     {
+        $table = $this->removeTableNamespaces($table);
+
         if (($this->shouldRemoveTablePrefix()) && (substr($table, 0, strlen($this->tablePrefix)) == $this->tablePrefix)) {
             $table = substr($table, strlen($this->tablePrefix));
         }


### PR DESCRIPTION
Make it possible to create a nested (unlimited depth) structure of models.

For example:

Tables:
`users`
`task_tracker__task`

Output models folder structure:
- Base
- - User.php
- User.php
- TaskTracker
- - Base
- - - Task.php
- - Task.php

namespace in Task.php: `namespace App\Models\TaskTracker;`

