### PR TITLE
Fix constant names on casts and fillable

### DIFF
--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -254,7 +254,7 @@ class Model
         // TODO: Check type cast is OK
         $cast = $column->type;
 
-        $propertyName = $this->usesPropertyConstants() ? 'self::'.strtoupper($column->name) : $column->name;
+        $propertyName = $this->usesPropertyConstants() ? 'self::'.strtoupper(Str::snake($column->name)) : $column->name;
 
         // Due to some casting problems when converting null to a Carbon instance,
         // we are going to treat Soft Deletes field as string.


### PR DESCRIPTION
Use case: the field name is `idAdmin`.

Before, the generated code was:

```
...
	const ID_ADMIN = 'idAdmin';
...
	protected $casts = [
		self::IDADMIN => 'int', // <- wrong constant
	];
```

After, it is:

```
...
	protected $casts = [
		self::ID_ADMIN => 'int'
	];

```