### PR TITLE
Add hidden property in BaseModels

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -416,6 +416,17 @@ return [
         'override_pluralize_for' => [
 
         ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Move $hidden property to base files
+        |--------------------------------------------------------------------------
+        | When base_files is true you can set hidden_in_base_files to true
+        | if you want the $hidden to be generated in base files
+        |
+        */
+        'hidden_in_base_files' => false,
+
         /*
         |--------------------------------------------------------------------------
         | Move $fillable property to base files

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -459,7 +459,7 @@ class Factory
             $body .= $this->class->field('casts', $model->getCasts(), ['before' => "\n"]);
         }
 
-        if ($model->hasHidden() && $model->doesNotUseBaseFiles()) {
+        if ($model->hasHidden() && ($model->doesNotUseBaseFiles() || $model->hiddenInBaseFiles())) {
             $body .= $this->class->field('hidden', $model->getHidden(), ['before' => "\n"]);
         }
 
@@ -575,7 +575,7 @@ class Factory
     {
         $body = '';
 
-        if ($model->hasHidden()) {
+        if ($model->hasHidden() && !$model->hiddenInBaseFiles()) {
             $body .= $this->class->field('hidden', $model->getHidden());
         }
 

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -1256,6 +1256,14 @@ class Model
     /**
      * @return bool
      */
+    public function hiddenInBaseFiles(): bool
+    {
+        return $this->config('hidden_in_base_files', false);
+    }
+
+    /**
+     * @return bool
+     */
     public function definesReturnTypes()
     {
         return $this->definesReturnTypes;


### PR DESCRIPTION
Hello,

In the same way as the `$fillable` property in BaseModels https://github.com/reliese/laravel/issues/57, I thought it could be useful to get the same behavior for the `$hidden` property. 

This PR should close this issue https://github.com/reliese/laravel/issues/238


