### PR TITLE
Use preg_replace rather than str_replace

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -337,7 +337,7 @@ class Factory
                 }
 
                 $importableDependencies[trim($usedClass, '\\')] = true;
-                $placeholder = str_replace($usedClass, $className, $placeholder);
+                $placeholder = preg_replace('!'.addslashes($usedClass).'\b!', addslashes($className), $placeholder, 1);
             }
         }
 


### PR DESCRIPTION
This ensures we only make 1 replacement, rather than potentially matching sub-strings in other FQCNs.

FIxes #278