### PR TITLE
Fix: for Issue with Model Generation in PostgreSQL with Multiple Schemas

### DIFF
--- a/src/Meta/Postgres/Schema.php
+++ b/src/Meta/Postgres/Schema.php
@@ -132,7 +132,16 @@ class Schema implements \Reliese\Meta\Schema
             LEFT JOIN pg_attribute parent on parent.attnum = ANY (p.confkey)
                 AND parent.attrelid = p.confrelid
             LEFT JOIN pg_class parent_class on parent_class.oid = p.confrelid
-        WHERE child_class.relkind = \'r\'::char
+        WHERE child.attrelid in (
+                SELECT oid
+                FROM pg_class
+                WHERE relnamespace in (
+                    SELECT oid
+                    FROM pg_namespace
+                    WHERE nspname = \'public\'
+                )
+            )
+            AND child_class.relkind = \'r\'::char
             AND child_class.relname = \''.$blueprint->table().'\'
             AND child.attnum > 0
             AND contype IS NOT NULL


### PR DESCRIPTION
## Phenomenon

- When using PostgreSQL, if there are schemas other than the `public` schema, the `Model` is not generated correctly.

## Cause

- When executing the SQL to retrieve table metadata for generating the `Model`, the data is duplicated for each schema.

## Solution

- Modify the SQL statement to only retrieve metadata from the `public` schema, even when multiple schemas exist.