### PR TITLE
Add MariaDB to supported databases

### DIFF
--- a/src/Meta/SchemaManager.php
+++ b/src/Meta/SchemaManager.php
@@ -25,6 +25,7 @@ class SchemaManager implements IteratorAggregate
      */
     protected static $lookup = [
         MySqlConnection::class => MySqlSchema::class,
+        MariaDbConnection::class => MySqlSchema::class,
         SQLiteConnection::class => SqliteSchema::class,
         PostgresConnection::class => PostgresSchema::class,
         \Larapack\DoctrineSupport\Connections\MySqlConnection::class => MySqlSchema::class,

--- a/src/Meta/SchemaManager.php
+++ b/src/Meta/SchemaManager.php
@@ -13,6 +13,7 @@ use IteratorAggregate;
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\MariaDbConnection;
 use Illuminate\Database\ConnectionInterface;
 use Reliese\Meta\MySql\Schema as MySqlSchema;
 use Reliese\Meta\Sqlite\Schema as SqliteSchema;


### PR DESCRIPTION
Add MariaDb to MySql alias to allow model creating when using MariaDB.