### PR TITLE
Solves problem with postgresql databases in Laravel 11

### DIFF
--- a/src/Meta/Postgres/Schema.php
+++ b/src/Meta/Postgres/Schema.php
@@ -283,7 +283,8 @@ class Schema implements \Reliese\Meta\Schema
      */
     public static function schemas(Connection $connection)
     {
-        $schemas = $connection->getDoctrineSchemaManager()->listDatabases();
+        $schemas = $connection->select('SELECT datname FROM pg_database');
+        $schemas = array_column($schemas, 'datname');
 
         return array_diff($schemas, [
             'postgres',


### PR DESCRIPTION
This PR fixes the `schemas()` method to stop using Doctrine. It treats "schemas" as "databases" instead of "PostgreSQL Schemas" as stated in a comment in the same file. It's not a big change, but it now works perfectly with PostgreSQL connections and partially addresses issues #286 and #292.