### PR TITLE
Add support for column lists in base models

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -396,6 +396,19 @@ return [
         'with_property_constants' => false,
 
         /*
+         |--------------------------------------------------------------------------
+         | Optionally includes a full list of columns in the base generated models,
+         | which can be used to avoid making calls like
+         |
+         | ...
+         | \Illuminate\Support\Facades\Schema::getColumnListing
+         | ...
+         |
+         | which can be slow, especially for large tables.
+         */
+        'with_column_list' => false,
+
+        /*
         |--------------------------------------------------------------------------
         | Disable Pluralization Name
         |--------------------------------------------------------------------------

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -455,6 +455,13 @@ class Factory
             $body .= $this->class->field('snakeAttributes', false, ['visibility' => 'public static']);
         }
 
+        if ($model->usesColumnList()) {
+            $properties = array_keys($model->getProperties());
+
+            $body .= "\n";
+            $body .= $this->class->field('columns', $properties);
+        }
+
         if ($model->hasCasts()) {
             $body .= $this->class->field('casts', $model->getCasts(), ['before' => "\n"]);
         }

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -1210,6 +1210,11 @@ class Model
         return $this->config('with_property_constants', false);
     }
 
+    public function usesColumnList()
+    {
+        return $this->config('with_column_list', false);
+    }
+
     /**
      * @return int
      */


### PR DESCRIPTION
The idea behind this change is to include a full list of columns in the generated models. This aims to reduce the need for making calls such as `\Illuminate\Support\Facades\Schema::getColumnListing`, which can be costly when done for large tables / in high-throughput environments.

This is not an on-by-default feature either - instead you must opt-in by using the new `with_column_list` setting in `config/models.php`.