### PR TITLE
allow specifying model path and name space 

### DIFF
--- a/src/Coders/Model/Config.php
+++ b/src/Coders/Model/Config.php
@@ -41,6 +41,7 @@ class Config
             "@connections.{$blueprint->connection()}.{$blueprint->schema()}.$key",
             "@connections.{$blueprint->connection()}.$key",
             "{$blueprint->qualifiedTable()}.$key",
+            "{$blueprint->table()}.$key", // <-- Added this line
             "{$blueprint->schema()}.$key",
             "*.$key",
         ];

--- a/src/Coders/Model/Config.php
+++ b/src/Coders/Model/Config.php
@@ -41,7 +41,7 @@ class Config
             "@connections.{$blueprint->connection()}.{$blueprint->schema()}.$key",
             "@connections.{$blueprint->connection()}.$key",
             "{$blueprint->qualifiedTable()}.$key",
-            "{$blueprint->table()}.$key", // <-- Added this line
+            "{$blueprint->table()}.$key",
             "{$blueprint->schema()}.$key",
             "*.$key",
         ];

--- a/src/Coders/Model/Config.php
+++ b/src/Coders/Model/Config.php
@@ -41,7 +41,7 @@ class Config
             "@connections.{$blueprint->connection()}.{$blueprint->schema()}.$key",
             "@connections.{$blueprint->connection()}.$key",
             "{$blueprint->qualifiedTable()}.$key",
-            "{$blueprint->table()}.$key",
+            "*.models.{$blueprint->table()}.$key",
             "{$blueprint->schema()}.$key",
             "*.$key",
         ];


### PR DESCRIPTION
example usage in config 

     

   'models' => [

            'searches' => [
                'namespace' => 'Modules\Search\Models',
                'path' => base_path('Modules/Search/Models'),
            ],
        ],