### PR TITLE
PHP8.4 - fix - PHP Deprecated:  Reliese\Coders\Model\Factory::config(): Implic…

### DIFF
--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -603,7 +603,7 @@ class Factory
      *
      * @return mixed|\Reliese\Coders\Model\Config
      */
-    public function config(Blueprint $blueprint = null, $key = null, $default = null)
+    public function config(?Blueprint $blueprint = null, $key = null, $default = null)
     {
         if (is_null($blueprint)) {
             return $this->config;


### PR DESCRIPTION
…itly marking parameter $blueprint as nullable is deprecated, the explicit nullable type must be used instead in src/Coders/Model/Factory.php on line 606