### PR TITLE
Fix WhoDidIt returning CLI for authenticated sessions when running Tests

### DIFF
--- a/src/Database/Eloquent/WhoDidIt.php
+++ b/src/Database/Eloquent/WhoDidIt.php
@@ -48,7 +48,7 @@ class WhoDidIt
      */
     protected function doer()
     {
-        if (app()->runningInConsole()) {
+        if (app()->runningInConsole() && (!$this->authenticated() || !app()->runningUnitTests())) {
             return 'CLI';
         }
 


### PR DESCRIPTION
This should fix an issue that occurs when using the blamable behavior and attempting to run tests.

Before, WhoDidIt would return 'CLI' when running tests from console, despite the session being authenticated.
With this change, if a test is ran and it sets a user, it will return the ID of the authenticated user instead of 'CLI'.