### PR TITLE
Fix for a couple of dprecations in PHP 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ fit your database needs. [Check it out](https://github.com/reliese/laravel/blob/
 #### 1. Keeping model changes
 
 You may want to generate your models as often as you change your database. In order
-not to lose you own model changes, you should set `base_files` to `true` in your `config/models.php`.
+not to lose your own model changes, you should set `base_files` to `true` in your `config/models.php`.
 
 When you enable this feature your models will inherit their base configurations from
 base models. You should avoid adding code to your base models, since you

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Laravel Model Generator
+# Reliese Laravel Model Generator
 [![Build Status](https://travis-ci.org/reliese/laravel.svg?branch=master)](https://travis-ci.org/reliese/laravel)
 [![Latest Stable Version](https://poser.pugx.org/reliese/laravel/v/stable)](https://packagist.org/packages/reliese/laravel)
 [![Total Downloads](https://poser.pugx.org/reliese/laravel/downloads)](https://packagist.org/packages/reliese/laravel)
 [![Latest Unstable Version](https://poser.pugx.org/reliese/laravel/v/unstable)](https://packagist.org/packages/reliese/laravel)
 [![License](https://poser.pugx.org/reliese/laravel/license)](https://packagist.org/packages/reliese/laravel)
 
-Laravel Model Generator aims to speed up the development process of Laravel applications by 
+Reliese Laravel Model Generator aims to speed up the development process of Laravel applications by 
 providing some convenient code-generation capabilities. 
 The tool inspects your database structure, including column names and foreign keys, in order 
 to automatically generate Models that have correctly typed properties, along with any relationships to other Models.

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ public function register()
 }
 ```
 
-## Models
-
-![Generating models with artisan](https://cdn-images-1.medium.com/max/800/1*hOa2QxORE2zyO_-ZqJ40sA.png "Making artisan code my Eloquent models")
-
 Add the `models.php` configuration file to your `config` directory and clear the config cache:
 
 ```shell
 php artisan vendor:publish --tag=reliese-models
 php artisan config:clear
 ```
+
+## Models
+
+![Generating models with artisan](https://cdn-images-1.medium.com/max/800/1*hOa2QxORE2zyO_-ZqJ40sA.png "Making artisan code my Eloquent models")
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -23,21 +23,12 @@ It is recommended that this package should only be used on a local environment f
 composer require reliese/laravel --dev
 ```
 
-Then you'll need to register the provider in `app/Providers/AppServiceProvider.php` file.
-
-```php
-public function register()
-{
-    if ($this->app->environment() == 'local') {
-        $this->app->register(\Reliese\Coders\CodersServiceProvider::class);
-    }
-}
-```
-
 Add the `models.php` configuration file to your `config` directory and clear the config cache:
 
 ```shell
 php artisan vendor:publish --tag=reliese-models
+
+# Let's refresh our config cache just in case
 php artisan config:clear
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# Reliese Laravel
+# Laravel Model Generator
 [![Build Status](https://travis-ci.org/reliese/laravel.svg?branch=master)](https://travis-ci.org/reliese/laravel)
 [![Latest Stable Version](https://poser.pugx.org/reliese/laravel/v/stable)](https://packagist.org/packages/reliese/laravel)
 [![Total Downloads](https://poser.pugx.org/reliese/laravel/downloads)](https://packagist.org/packages/reliese/laravel)
 [![Latest Unstable Version](https://poser.pugx.org/reliese/laravel/v/unstable)](https://packagist.org/packages/reliese/laravel)
 [![License](https://poser.pugx.org/reliese/laravel/license)](https://packagist.org/packages/reliese/laravel)
 
-Reliese Laravel is a collection of Laravel Components which aim is 
-to help the development process of Laravel applications by 
-providing some convenient code-generation capabilities.
+Laravel Model Generator aims to speed up the development process of Laravel applications by 
+providing some convenient code-generation capabilities. 
+The tool inspects your database structure, including column names and foreign keys, in order 
+to automatically generate Models that have correctly typed properties, along with any relationships to other Models.
 
 ## How does it work?
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4",
+        "php": "^7.3|^8.0",
         "doctrine/dbal": ">=2.5",
         "illuminate/support": ">=5.1",
         "illuminate/database": ">=5.1",

--- a/config/models.php
+++ b/config/models.php
@@ -421,6 +421,18 @@ return [
         |
         */
         'fillable_in_base_files' => false,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Generate return types for relation methods.
+        |--------------------------------------------------------------------------
+        | When enable_return_types is set to true, return type declarations are added
+        | to all generated relation methods for your models.
+        |
+        | NOTE: This requires PHP 7.0 or later.
+        |
+        */
+        'enable_return_types' => false,
     ],
 
     /*

--- a/config/models.php
+++ b/config/models.php
@@ -412,6 +412,15 @@ return [
         'override_pluralize_for' => [
 
         ],
+        /*
+        |--------------------------------------------------------------------------
+        | Move $fillable property to base files
+        |--------------------------------------------------------------------------
+        | When base_files is true you can set fillable_in_base_files to true 
+        | if you want the $fillable to be generated in base files
+        |
+        */
+        'fillable_in_base_files' => false,
     ],
 
     /*

--- a/config/models.php
+++ b/config/models.php
@@ -396,6 +396,19 @@ return [
         'with_property_constants' => false,
 
         /*
+         |--------------------------------------------------------------------------
+         | Optionally includes a full list of columns in the base generated models,
+         | which can be used to avoid making calls like
+         |
+         | ...
+         | \Illuminate\Support\Facades\Schema::getColumnListing
+         | ...
+         |
+         | which can be slow, especially for large tables.
+         */
+        'with_column_list' => false,
+
+        /*
         |--------------------------------------------------------------------------
         | Disable Pluralization Name
         |--------------------------------------------------------------------------

--- a/config/models.php
+++ b/config/models.php
@@ -333,14 +333,19 @@ return [
                             generates Post::user() and User::posts()
         |
         | 'foreign_key' Use the foreign key as the relation name.
-        |                   (post.author --> user.id)
-        |                       generates Post::author() and User::posts_author()
-        |               Column id's are ignored.
+        |               This can help to provide more meaningful relationship names, and avoids naming conflicts
+        |               if you have more than one relationship between two tables.
         |                   (post.author_id --> user.id)
+        |                       generates Post::author() and User::posts_where_author()
+        |                   (post.editor_id --> user.id)
+        |                       generates Post::editor() and User::posts_where_editor()
+        |               ID suffixes can be omitted from foreign keys.
+        |                   (post.author --> user.id)
+        |                   (post.editor --> user.id)
         |                       generates the same as above.
-        |               When the foreign key is redundant, it is omited.
+        |               Where the foreign key matches the related table name, it behaves as per the 'related' strategy.
         |                   (post.user_id --> user.id)
-        |                       generates User::posts() and not User::posts_user()
+        |                       generates Post::user() and User::posts()
         */
 
         'relation_name_strategy' => 'related',

--- a/config/models.php
+++ b/config/models.php
@@ -416,6 +416,17 @@ return [
         'override_pluralize_for' => [
 
         ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Move $hidden property to base files
+        |--------------------------------------------------------------------------
+        | When base_files is true you can set hidden_in_base_files to true
+        | if you want the $hidden to be generated in base files
+        |
+        */
+        'hidden_in_base_files' => false,
+
         /*
         |--------------------------------------------------------------------------
         | Move $fillable property to base files

--- a/config/models.php
+++ b/config/models.php
@@ -161,7 +161,7 @@ return [
         | Base Files
         |--------------------------------------------------------------------------
         |
-        | By default, your models will be generated in your models' path, but
+        | By default, your models will be generated in your models path, but
         | when you generate them again they will be replaced by new ones.
         | You may want to customize your models and, at the same time, be
         | able to generate them as your tables change. For that, you
@@ -254,7 +254,7 @@ return [
         |--------------------------------------------------------------------------
         |
         | You may want to specify which of your table fields should be cast as
-        | something different from a string. For instance, you may want a
+        | something other than a string. For instance, you may want a
         | text field be cast as an array or and object.
         |
         | You may define column patterns which will be cast using the value
@@ -284,13 +284,7 @@ return [
             'failed_jobs',
             'password_resets',
             'personal_access_tokens',
-            'notifications',
-            'nova_field_attachments',
-            'nova_notifications',
-            'nova_pending_field_attachments',
-            'telescope_entries',
-            'telescope_entries_tags',
-            'telescope_monitoring',
+            'password_reset_tokens',
         ],
 
         /*

--- a/config/models.php
+++ b/config/models.php
@@ -323,6 +323,26 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Model Names
+        |--------------------------------------------------------------------------
+        |
+        | By default the generator will create models with names that match your tables.
+        | However, if you wish to manually override the naming, you can specify a mapping
+        | here between table and model names.
+        |
+        | Example:
+        |   A table called 'billing_invoices' will generate a model called `BillingInvoice`,
+        |   but you'd prefer it to generate a model called 'Invoice'. Therefore, you'd add
+        |   the following array key and value:
+        |     'billing_invoices' => 'Invoice',
+        */
+
+        'model_names' => [
+
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
         | Relation Name Strategy
         |--------------------------------------------------------------------------
         |

--- a/config/models.php
+++ b/config/models.php
@@ -161,7 +161,7 @@ return [
         | Base Files
         |--------------------------------------------------------------------------
         |
-        | By default, your models will be generated in your models path, but
+        | By default, your models will be generated in your models' path, but
         | when you generate them again they will be replaced by new ones.
         | You may want to customize your models and, at the same time, be
         | able to generate them as your tables change. For that, you
@@ -211,7 +211,7 @@ return [
         | TRUE: Schema name will be prepended on the table
         | FALSE:Table name will be set without schema name.
         | NULL: Table name will follow laravel pattern,
-        |   i.e if class name(plural) matches table name, then table name will not be added
+        |   i.e. if class name(plural) matches table name, then table name will not be added
         */
 
         'qualified_tables' => false,
@@ -253,11 +253,11 @@ return [
         | Casts
         |--------------------------------------------------------------------------
         |
-        | You may want to specify which of your table fields should be casted as
-        | something different than a string. For instance, you may want a
-        | text field be casted as an array or and object.
+        | You may want to specify which of your table fields should be cast as
+        | something different from a string. For instance, you may want a
+        | text field be cast as an array or and object.
         |
-        | You may define column patterns which will be casted using the value
+        | You may define column patterns which will be cast using the value
         | assigned. We have defined some fields for you. Feel free to
         | modify them to fit your needs.
         |
@@ -281,6 +281,16 @@ return [
 
         'except' => [
             'migrations',
+            'failed_jobs',
+            'password_resets',
+            'personal_access_tokens',
+            'notifications',
+            'nova_field_attachments',
+            'nova_notifications',
+            'nova_pending_field_attachments',
+            'telescope_entries',
+            'telescope_entries_tags',
+            'telescope_monitoring',
         ],
 
         /*
@@ -416,7 +426,7 @@ return [
         |--------------------------------------------------------------------------
         | Move $fillable property to base files
         |--------------------------------------------------------------------------
-        | When base_files is true you can set fillable_in_base_files to true 
+        | When base_files is true you can set fillable_in_base_files to true
         | if you want the $fillable to be generated in base files
         |
         */

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -7,12 +7,12 @@
 
 namespace Reliese\Coders\Model;
 
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 use Reliese\Meta\Blueprint;
-use Reliese\Support\Classify;
 use Reliese\Meta\SchemaManager;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Database\DatabaseManager;
+use Reliese\Support\Classify;
 
 class Factory
 {
@@ -480,7 +480,14 @@ class Factory
         }
 
         foreach ($model->getRelations() as $constraint) {
-            $body .= $this->class->method($constraint->name(), $constraint->body(), ['before' => "\n"]);
+            $body .= $this->class->method(
+                $constraint->name(),
+                $constraint->body(),
+                [
+                    'before' => "\n",
+                    'returnType' => $model->definesReturnTypes() ? $constraint->returnType() : null,
+                ]
+            );
         }
 
         // Make sure there not undesired line breaks

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -337,7 +337,7 @@ class Factory
                 }
 
                 $importableDependencies[trim($usedClass, '\\')] = true;
-                $placeholder = str_replace($usedClass, $className, $placeholder);
+                $placeholder = preg_replace('!'.addslashes($usedClass).'\b!', addslashes($className), $placeholder, 1);
             }
         }
 

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -603,7 +603,7 @@ class Factory
      *
      * @return mixed|\Reliese\Coders\Model\Config
      */
-    public function config(Blueprint $blueprint = null, $key = null, $default = null)
+    public function config(?Blueprint $blueprint = null, $key = null, $default = null)
     {
         if (is_null($blueprint)) {
             return $this->config;

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -455,6 +455,13 @@ class Factory
             $body .= $this->class->field('snakeAttributes', false, ['visibility' => 'public static']);
         }
 
+        if ($model->usesColumnList()) {
+            $properties = array_keys($model->getProperties());
+
+            $body .= "\n";
+            $body .= $this->class->field('columns', $properties);
+        }
+
         if ($model->hasCasts()) {
             $body .= $this->class->field('casts', $model->getCasts(), ['before' => "\n"]);
         }

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -459,7 +459,7 @@ class Factory
             $body .= $this->class->field('casts', $model->getCasts(), ['before' => "\n"]);
         }
 
-        if ($model->hasHidden() && $model->doesNotUseBaseFiles()) {
+        if ($model->hasHidden() && ($model->doesNotUseBaseFiles() || $model->hiddenInBaseFiles())) {
             $body .= $this->class->field('hidden', $model->getHidden(), ['before' => "\n"]);
         }
 
@@ -575,7 +575,7 @@ class Factory
     {
         $body = '';
 
-        if ($model->hasHidden()) {
+        if ($model->hasHidden() && !$model->hiddenInBaseFiles()) {
             $body .= $this->class->field('hidden', $model->getHidden());
         }
 

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -459,10 +459,6 @@ class Factory
             $body .= $this->class->field('casts', $model->getCasts(), ['before' => "\n"]);
         }
 
-        if ($model->hasDates()) {
-            $body .= $this->class->field('dates', $model->getDates(), ['before' => "\n"]);
-        }
-
         if ($model->hasHidden() && $model->doesNotUseBaseFiles()) {
             $body .= $this->class->field('hidden', $model->getHidden(), ['before' => "\n"]);
         }

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -319,6 +319,15 @@ class Factory
                 $namespacePieces = explode('\\', $usedClass);
                 $className = array_pop($namespacePieces);
 
+                /**
+                 * Avoid breaking same-model relationships when using base classes
+                 *
+                 * @see https://github.com/reliese/laravel/issues/209
+                 */
+                if ($usedClass === $model->getQualifiedUserClassName()) {
+                    continue;
+                }
+
                 //When same class name but different namespace, skip it.
                 if (
                     $className == $model->getClassName() &&

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -567,7 +567,7 @@ class Factory
             $body .= $this->class->field('hidden', $model->getHidden());
         }
 
-        if ($model->hasFillable()&& !$model->fillableInBaseFiles()) {
+        if ($model->hasFillable() && !$model->fillableInBaseFiles()) {
             $body .= $this->class->field('fillable', $model->getFillable(), ['before' => "\n"]);
         }
 

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -324,7 +324,7 @@ class Factory
                  *
                  * @see https://github.com/reliese/laravel/issues/209
                  */
-                if ($usedClass === $model->getQualifiedUserClassName()) {
+                if ($model->usesBaseFiles() && $usedClass === $model->getQualifiedUserClassName()) {
                     continue;
                 }
 

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -458,7 +458,7 @@ class Factory
             $body .= $this->class->field('hidden', $model->getHidden(), ['before' => "\n"]);
         }
 
-        if ($model->hasFillable() && $model->doesNotUseBaseFiles()) {
+        if ($model->hasFillable() && ($model->doesNotUseBaseFiles() || $model->fillableInBaseFiles())) {
             $body .= $this->class->field('fillable', $model->getFillable(), ['before' => "\n"]);
         }
 
@@ -567,7 +567,7 @@ class Factory
             $body .= $this->class->field('hidden', $model->getHidden());
         }
 
-        if ($model->hasFillable()) {
+        if ($model->hasFillable()&& !$model->fillableInBaseFiles()) {
             $body .= $this->class->field('fillable', $model->getFillable(), ['before' => "\n"]);
         }
 

--- a/src/Coders/Model/Factory.php
+++ b/src/Coders/Model/Factory.php
@@ -390,7 +390,8 @@ class Factory
             $properties = array_diff($properties, $excludedConstants);
 
             foreach ($properties as $property) {
-                $body .= $this->class->constant(strtoupper($property), $property);
+                $constantName = Str::upper(Str::snake($property));
+                $body .= $this->class->constant($constantName, $property);
             }
         }
 

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -163,6 +163,11 @@ class Model
     protected $relationNameStrategy = '';
 
     /**
+     * @var bool
+     */
+    protected $definesReturnTypes = false;
+
+    /**
      * ModelClass constructor.
      *
      * @param \Reliese\Meta\Blueprint $blueprint
@@ -209,6 +214,8 @@ class Model
 
         // Relation name settings
         $this->withRelationNameStrategy($this->config('relation_name_strategy', $this->getDefaultRelationNameStrategy()));
+
+        $this->definesReturnTypes = $this->config('enable_return_types', false);
 
         return $this;
     }
@@ -1248,5 +1255,13 @@ class Model
     public function fillableInBaseFiles(): bool
     {
         return $this->config('fillable_in_base_files', false);
+    }
+
+    /**
+     * @return bool
+     */
+    public function definesReturnTypes()
+    {
+        return $this->definesReturnTypes;
     }
 }

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -352,7 +352,7 @@ class Model
             case 'collection':
                 $type = '\Illuminate\Support\Collection';
                 break;
-            case 'date':
+            case 'datetime':
                 $type = '\Carbon\Carbon';
                 break;
             case 'binary':
@@ -994,7 +994,7 @@ class Model
     {
         return array_diff(
             array_filter($this->casts, function (string $cast) {
-                return $cast === 'date';
+                return $cast === 'datetime';
             }),
             [$this->CREATED_AT, $this->UPDATED_AT]
         );

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -1210,6 +1210,11 @@ class Model
         return $this->config('with_property_constants', false);
     }
 
+    public function usesColumnList()
+    {
+        return $this->config('with_column_list', false);
+    }
+
     /**
      * @return int
      */

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -70,11 +70,6 @@ class Model
     /**
      * @var array
      */
-    protected $dates = [];
-
-    /**
-     * @var array
-     */
     protected $hints = [];
 
     /**
@@ -267,12 +262,8 @@ class Model
             $cast = 'string';
         }
 
-        // Track dates
-        if ($cast == 'date') {
-            $this->dates[] = $propertyName;
-        }
-        // Track attribute casts
-        elseif ($cast != 'string') {
+        // Track attribute casts, ignoring timestamps
+        if ($cast != 'string' && !in_array($propertyName, [$this->CREATED_AT, $this->UPDATED_AT])) {
             $this->casts[$propertyName] = $cast;
         }
 
@@ -1001,7 +992,12 @@ class Model
      */
     public function getDates()
     {
-        return array_diff($this->dates, [$this->CREATED_AT, $this->UPDATED_AT]);
+        return array_diff(
+            array_filter($this->casts, function (string $cast) {
+                return $cast === 'date';
+            }),
+            [$this->CREATED_AT, $this->UPDATED_AT]
+        );
     }
 
     /**

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -1256,6 +1256,14 @@ class Model
     /**
      * @return bool
      */
+    public function hiddenInBaseFiles(): bool
+    {
+        return $this->config('hidden_in_base_files', false);
+    }
+
+    /**
+     * @return bool
+     */
     public function definesReturnTypes()
     {
         return $this->definesReturnTypes;

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -1241,4 +1241,12 @@ class Model
     {
         return $this->factory->config($this->getBlueprint(), $key, $default);
     }
+
+    /**
+     * @return bool
+     */
+    public function fillableInBaseFiles(): bool
+    {
+        return $this->config('fillable_in_base_files', false);
+    }
 }

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -521,7 +521,7 @@ class Model
      */
     public function getClassName()
     {
-        // Model names can be manually configured by users in the config file.
+        // Model names can be manually overridden by users in the config file.
         // If a config entry exists for this table, use that name, rather than generating one.
         $overriddenName = $this->config('model_names.' . $this->getTable());
         if ($overriddenName) {

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -521,6 +521,13 @@ class Model
      */
     public function getClassName()
     {
+        // Model names can be manually configured by users in the config file.
+        // If a config entry exists for this table, use that name, rather than generating one.
+        $overriddenName = $this->config('model_names.' . $this->getTable());
+        if ($overriddenName) {
+            return $overriddenName;
+        }
+
         if ($this->shouldLowerCaseTableName()) {
             return Str::studly(Str::lower($this->getRecordName()));
         }

--- a/src/Coders/Model/ModelManager.php
+++ b/src/Coders/Model/ModelManager.php
@@ -65,7 +65,7 @@ class ModelManager implements IteratorAggregate
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->models);
     }

--- a/src/Coders/Model/Relation.php
+++ b/src/Coders/Model/Relation.php
@@ -23,4 +23,9 @@ interface Relation
      * @return string
      */
     public function body();
+
+    /**
+     * @return string
+     */
+    public function returnType();
 }

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -128,6 +128,14 @@ class BelongsTo implements Relation
     }
 
     /**
+     * @return string
+     */
+    public function returnType()
+    {
+        return \Illuminate\Database\Eloquent\Relations\BelongsTo::class;
+    }
+
+    /**
      * @return bool
      */
     protected function needsForeignKey()

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -51,16 +51,11 @@ class BelongsTo implements Relation
     {
         switch ($this->parent->getRelationNameStrategy()) {
             case 'foreign_key':
-                $relationName = $this->foreignKey();
-                $primaryKey = $this->otherKey();
-                // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
-                if ($this->parent->usesSnakeAttributes()) {
-                    $lowerPrimaryKey = strtolower($primaryKey);
-                    $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
-                } else {
-                    $studlyPrimaryKey = Str::studly($primaryKey);
-                    $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
-                }
+                $relationName = RelationHelper::stripSuffixFromForeignKey(
+                    $this->parent->usesSnakeAttributes(),
+                    $this->otherKey(),
+                    $this->foreignKey()
+                );
                 break;
             default:
             case 'related':

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -7,11 +7,11 @@
 
 namespace Reliese\Coders\Model\Relations;
 
-use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
+use Reliese\Support\Dumper;
+use Illuminate\Support\Fluent;
 use Reliese\Coders\Model\Model;
 use Reliese\Coders\Model\Relation;
-use Reliese\Support\Dumper;
 
 class BelongsTo implements Relation
 {

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -49,15 +49,26 @@ class BelongsTo implements Relation
      */
     public function name()
     {
-        switch ($this->parent->getRelationNameStrategy()) {
-            case 'foreign_key':
-                $relationName = preg_replace("/[^a-zA-Z0-9]?{$this->otherKey()}$/", '', $this->foreignKey());
-                break;
-            default:
-            case 'related':
-                $relationName = $this->related->getClassName();
-                break;
-        }
+//        if ($this->related->getClassName() === 'Employee') {
+            $relationName = $this->foreignKey();
+            // chop off 'id'
+            if ($this->parent->usesSnakeAttributes()) {
+                $relationName = preg_replace('/_id$/', '', $relationName);
+            } else {
+                $relationName = preg_replace('/(Id)|(ID)$/', '', $relationName);
+            }
+
+
+//        }
+//        switch ($this->parent->getRelationNameStrategy()) {
+//            case 'foreign_key':
+//                $relationName = preg_replace("/[^a-zA-Z0-9]?{$this->otherKey()}$/", '', $this->foreignKey());
+//                break;
+//            default:
+//            case 'related':
+//                $relationName = $this->related->getClassName();
+//                break;
+//        }
 
         if ($this->parent->usesSnakeAttributes()) {
             return Str::snake($relationName);

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -71,6 +71,73 @@ class BelongsTo implements Relation
     }
 
     /**
+     * @return string
+     */
+    public function body()
+    {
+        $body = 'return $this->belongsTo(';
+
+        $body .= $this->related->getQualifiedUserClassName().'::class';
+
+        if ($this->needsForeignKey()) {
+            $foreignKey = $this->parent->usesPropertyConstants()
+                ? $this->parent->getQualifiedUserClassName().'::'.strtoupper($this->foreignKey())
+                : $this->foreignKey();
+            $body .= ', '.Dumper::export($foreignKey);
+        }
+
+        if ($this->needsOtherKey()) {
+            $otherKey = $this->related->usesPropertyConstants()
+                ? $this->related->getQualifiedUserClassName().'::'.strtoupper($this->otherKey())
+                : $this->otherKey();
+            $body .= ', '.Dumper::export($otherKey);
+        }
+
+        $body .= ')';
+
+        if ($this->hasCompositeOtherKey()) {
+            // We will assume that when this happens the referenced columns are a composite primary key
+            // or a composite unique key. Otherwise it should be a has-many relationship which is not
+            // supported at the moment. @todo: Improve relationship resolution.
+            foreach ($this->command->references as $index => $column) {
+                $body .= "\n\t\t\t\t\t->where(".
+                    Dumper::export($this->qualifiedOtherKey($index)).
+                    ", '=', ".
+                    Dumper::export($this->qualifiedForeignKey($index)).
+                    ')';
+            }
+        }
+
+        $body .= ';';
+
+        return $body;
+    }
+
+    /**
+     * @return string
+     */
+    public function hint()
+    {
+        $base =  $this->related->getQualifiedUserClassName();
+
+        if ($this->isNullable()) {
+            $base .= '|null';
+        }
+
+        return $base;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function needsForeignKey()
+    {
+        $defaultForeignKey = $this->related->getRecordName().'_id';
+
+        return $defaultForeignKey != $this->foreignKey() || $this->needsOtherKey();
+    }
+
+    /**
      * @param int $index
      *
      * @return string
@@ -85,62 +152,9 @@ class BelongsTo implements Relation
      *
      * @return string
      */
-    protected function otherKey($index = 0)
+    protected function qualifiedForeignKey($index = 0)
     {
-        return $this->command->references[$index];
-    }
-
-    /**
-     * @return string
-     */
-    public function body()
-    {
-        $body = 'return $this->belongsTo(';
-
-        $body .= $this->related->getQualifiedUserClassName() . '::class';
-
-        if ($this->needsForeignKey()) {
-            $foreignKey = $this->parent->usesPropertyConstants()
-                ? $this->parent->getQualifiedUserClassName() . '::' . strtoupper($this->foreignKey())
-                : $this->foreignKey();
-            $body .= ', ' . Dumper::export($foreignKey);
-        }
-
-        if ($this->needsOtherKey()) {
-            $otherKey = $this->related->usesPropertyConstants()
-                ? $this->related->getQualifiedUserClassName() . '::' . strtoupper($this->otherKey())
-                : $this->otherKey();
-            $body .= ', ' . Dumper::export($otherKey);
-        }
-
-        $body .= ')';
-
-        if ($this->hasCompositeOtherKey()) {
-            // We will assume that when this happens the referenced columns are a composite primary key
-            // or a composite unique key. Otherwise it should be a has-many relationship which is not
-            // supported at the moment. @todo: Improve relationship resolution.
-            foreach ($this->command->references as $index => $column) {
-                $body .= "\n\t\t\t\t\t->where(" .
-                         Dumper::export($this->qualifiedOtherKey($index)) .
-                         ", '=', " .
-                         Dumper::export($this->qualifiedForeignKey($index)) .
-                         ')';
-            }
-        }
-
-        $body .= ';';
-
-        return $body;
-    }
-
-    /**
-     * @return bool
-     */
-    protected function needsForeignKey()
-    {
-        $defaultForeignKey = $this->related->getRecordName() . '_id';
-
-        return $defaultForeignKey != $this->foreignKey() || $this->needsOtherKey();
+        return $this->parent->getTable().'.'.$this->foreignKey($index);
     }
 
     /**
@@ -154,6 +168,26 @@ class BelongsTo implements Relation
     }
 
     /**
+     * @param int $index
+     *
+     * @return string
+     */
+    protected function otherKey($index = 0)
+    {
+        return $this->command->references[$index];
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return string
+     */
+    protected function qualifiedOtherKey($index = 0)
+    {
+        return $this->related->getTable().'.'.$this->otherKey($index);
+    }
+
+    /**
      * Whether the "other key" is a composite foreign key.
      *
      * @return bool
@@ -164,44 +198,10 @@ class BelongsTo implements Relation
     }
 
     /**
-     * @param int $index
-     *
-     * @return string
-     */
-    protected function qualifiedOtherKey($index = 0)
-    {
-        return $this->related->getTable() . '.' . $this->otherKey($index);
-    }
-
-    /**
-     * @param int $index
-     *
-     * @return string
-     */
-    protected function qualifiedForeignKey($index = 0)
-    {
-        return $this->parent->getTable() . '.' . $this->foreignKey($index);
-    }
-
-    /**
-     * @return string
-     */
-    public function hint()
-    {
-        $base = $this->related->getQualifiedUserClassName();
-
-        if ($this->isNullable()) {
-            $base .= '|null';
-        }
-
-        return $base;
-    }
-
-    /**
      * @return bool
      */
     private function isNullable()
     {
-        return (bool)$this->parent->getBlueprint()->column($this->foreignKey())->get('nullable');
+        return (bool) $this->parent->getBlueprint()->column($this->foreignKey())->get('nullable');
     }
 }

--- a/src/Coders/Model/Relations/BelongsTo.php
+++ b/src/Coders/Model/Relations/BelongsTo.php
@@ -49,27 +49,24 @@ class BelongsTo implements Relation
      */
     public function name()
     {
-        $relationName = $this->foreignKey();
-        $primaryKey = $this->otherKey();
-        // chop off 'id'
-        if ($this->parent->usesSnakeAttributes()) {
-            $lowerPrimaryKey = strtolower($primaryKey);
-            $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
-        } else {
-            $studlyPrimaryKey = Str::studly($primaryKey);
-            $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
+        switch ($this->parent->getRelationNameStrategy()) {
+            case 'foreign_key':
+                $relationName = $this->foreignKey();
+                $primaryKey = $this->otherKey();
+                // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
+                if ($this->parent->usesSnakeAttributes()) {
+                    $lowerPrimaryKey = strtolower($primaryKey);
+                    $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
+                } else {
+                    $studlyPrimaryKey = Str::studly($primaryKey);
+                    $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
+                }
+                break;
+            default:
+            case 'related':
+                $relationName = $this->related->getClassName();
+                break;
         }
-
-
-//        switch ($this->parent->getRelationNameStrategy()) {
-//            case 'foreign_key':
-//                $relationName = preg_replace("/[^a-zA-Z0-9]?{$this->otherKey()}$/", '', $this->foreignKey());
-//                break;
-//            default:
-//            case 'related':
-//                $relationName = $this->related->getClassName();
-//                break;
-//        }
 
         if ($this->parent->usesSnakeAttributes()) {
             return Str::snake($relationName);

--- a/src/Coders/Model/Relations/BelongsToMany.php
+++ b/src/Coders/Model/Relations/BelongsToMany.php
@@ -137,6 +137,14 @@ class BelongsToMany implements Relation
     }
 
     /**
+     * @return string
+     */
+    public function returnType()
+    {
+        return \Illuminate\Database\Eloquent\Relations\BelongsToMany::class;
+    }
+
+    /**
      * @return bool
      */
     protected function needsPivotTable()

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -58,4 +58,12 @@ class HasMany extends HasOneOrMany
     {
         return 'hasMany';
     }
+
+    /**
+     * @return string
+     */
+    public function returnType()
+    {
+        return \Illuminate\Database\Eloquent\Relations\HasMany::class;
+    }
 }

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -25,50 +25,29 @@ class HasMany extends HasOneOrMany
      */
     public function name()
     {
-        $relationName = $this->foreignKey();
-        $primaryKey = $this->localKey();
-        // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
-        if ($this->parent->usesSnakeAttributes()) {
-            $lowerPrimaryKey = strtolower($primaryKey);
-            $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
-        } else {
-            $studlyPrimaryKey = Str::studly($primaryKey);
-            $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
+        switch ($this->parent->getRelationNameStrategy()) {
+            case 'foreign_key':
+                $relationName = $this->foreignKey();
+                $primaryKey = $this->localKey();
+                // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
+                if ($this->parent->usesSnakeAttributes()) {
+                    $lowerPrimaryKey = strtolower($primaryKey);
+                    $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
+                } else {
+                    $studlyPrimaryKey = Str::studly($primaryKey);
+                    $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
+                }
+                if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
+                    $relationName = Str::plural($this->related->getClassName());
+                } else {
+                    $relationName = Str::plural($this->related->getClassName()) . 'Where' . ucfirst(Str::singular($relationName));
+                }
+                break;
+            default:
+            case 'related':
+                $relationName = Str::plural($this->related->getClassName());
+                break;
         }
-
-        if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
-            $relationName = Str::plural($this->related->getClassName());
-        } else {
-            $relationName = Str::plural($this->related->getClassName()) . 'Where' . ucfirst(Str::singular($relationName));
-        }
-
-//        if ($this->parent->shouldPluralizeTableName()) {
-//            $relationBaseName = Str::plural(Str::singular($this->related->getTable(true)));
-//        } else {
-//            $relationBaseName = $this->related->getTable(true);
-//        }
-//
-//        if ($this->parent->shouldLowerCaseTableName()) {
-//            $relationBaseName = strtolower($relationBaseName);
-//        }
-//
-//        switch ($this->parent->getRelationNameStrategy()) {
-//            case 'foreign_key':
-//                $suffix = preg_replace("/[^a-zA-Z0-9]?{$this->localKey()}$/", '', $this->foreignKey());
-//
-//                $relationName = $relationBaseName;
-//
-//                // Don't make relations such as users_user, just leave it as 'users'.
-//                if ($this->parent->getTable(true) !== $suffix) {
-//                    $relationName .= "_{$suffix}";
-//                }
-//
-//                break;
-//            case 'related':
-//            default:
-//                $relationName = $relationBaseName;
-//                break;
-//        }
 
         if ($this->parent->usesSnakeAttributes()) {
             return Str::snake($relationName);

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -7,8 +7,8 @@
 
 namespace Reliese\Coders\Model\Relations;
 
-use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
 
 class HasMany extends HasOneOrMany
 {
@@ -26,12 +26,14 @@ class HasMany extends HasOneOrMany
     public function name()
     {
         $relationName = $this->foreignKey();
-
-        // chop off 'id'
+        $primaryKey = $this->localKey();
+        // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
         if ($this->parent->usesSnakeAttributes()) {
-            $relationName = preg_replace('/_id$/', '', $relationName);
+            $lowerPrimaryKey = strtolower($primaryKey);
+            $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
         } else {
-            $relationName = preg_replace('/(Id)|(ID)$/', '', $relationName);
+            $studlyPrimaryKey = Str::studly($primaryKey);
+            $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
         }
 
         if (strtolower($relationName) === strtolower($this->parent->getClassName())) {

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -25,33 +25,48 @@ class HasMany extends HasOneOrMany
      */
     public function name()
     {
-        if ($this->parent->shouldPluralizeTableName()) {
-            $relationBaseName = Str::plural(Str::singular($this->related->getTable(true)));
+        $relationName = $this->foreignKey();
+
+        // chop off 'id'
+        if ($this->parent->usesSnakeAttributes()) {
+            $relationName = preg_replace('/_id$/', '', $relationName);
         } else {
-            $relationBaseName = $this->related->getTable(true);
+            $relationName = preg_replace('/(Id)|(ID)$/', '', $relationName);
         }
 
-        if ($this->parent->shouldLowerCaseTableName()) {
-            $relationBaseName = strtolower($relationBaseName);
+        if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
+            $relationName = Str::plural($this->related->getClassName());
+        } else {
+            $relationName = Str::plural($this->related->getClassName()) . 'Where' . ucfirst(Str::singular($relationName));
         }
 
-        switch ($this->parent->getRelationNameStrategy()) {
-            case 'foreign_key':
-                $suffix = preg_replace("/[^a-zA-Z0-9]?{$this->localKey()}$/", '', $this->foreignKey());
-
-                $relationName = $relationBaseName;
-
-                // Don't make relations such as users_user, just leave it as 'users'.
-                if ($this->parent->getTable(true) !== $suffix) {
-                    $relationName .= "_{$suffix}";
-                }
-
-                break;
-            case 'related':
-            default:
-                $relationName = $relationBaseName;
-                break;
-        }
+//        if ($this->parent->shouldPluralizeTableName()) {
+//            $relationBaseName = Str::plural(Str::singular($this->related->getTable(true)));
+//        } else {
+//            $relationBaseName = $this->related->getTable(true);
+//        }
+//
+//        if ($this->parent->shouldLowerCaseTableName()) {
+//            $relationBaseName = strtolower($relationBaseName);
+//        }
+//
+//        switch ($this->parent->getRelationNameStrategy()) {
+//            case 'foreign_key':
+//                $suffix = preg_replace("/[^a-zA-Z0-9]?{$this->localKey()}$/", '', $this->foreignKey());
+//
+//                $relationName = $relationBaseName;
+//
+//                // Don't make relations such as users_user, just leave it as 'users'.
+//                if ($this->parent->getTable(true) !== $suffix) {
+//                    $relationName .= "_{$suffix}";
+//                }
+//
+//                break;
+//            case 'related':
+//            default:
+//                $relationName = $relationBaseName;
+//                break;
+//        }
 
         if ($this->parent->usesSnakeAttributes()) {
             return Str::snake($relationName);

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -7,8 +7,8 @@
 
 namespace Reliese\Coders\Model\Relations;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Collection;
 
 class HasMany extends HasOneOrMany
 {

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -32,7 +32,7 @@ class HasMany extends HasOneOrMany
                     $this->localKey(),
                     $this->foreignKey()
                 );
-                if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
+                if (Str::snake($relationName) === Str::snake($this->parent->getClassName())) {
                     $relationName = Str::plural($this->related->getClassName());
                 } else {
                     $relationName = Str::plural($this->related->getClassName()) . 'Where' . ucfirst(Str::singular($relationName));

--- a/src/Coders/Model/Relations/HasMany.php
+++ b/src/Coders/Model/Relations/HasMany.php
@@ -27,16 +27,11 @@ class HasMany extends HasOneOrMany
     {
         switch ($this->parent->getRelationNameStrategy()) {
             case 'foreign_key':
-                $relationName = $this->foreignKey();
-                $primaryKey = $this->localKey();
-                // Chop off primary key suffix of foreign key, if it exists (eg. lineManagerId => lineManager)
-                if ($this->parent->usesSnakeAttributes()) {
-                    $lowerPrimaryKey = strtolower($primaryKey);
-                    $relationName = preg_replace('/(_' . $primaryKey . ')|(_' . $lowerPrimaryKey . ')$/', '', $relationName);
-                } else {
-                    $studlyPrimaryKey = Str::studly($primaryKey);
-                    $relationName = preg_replace('/(' . $primaryKey . ')|(' . $studlyPrimaryKey . ')$/', '', $relationName);
-                }
+                $relationName = RelationHelper::stripSuffixFromForeignKey(
+                    $this->parent->usesSnakeAttributes(),
+                    $this->localKey(),
+                    $this->foreignKey()
+                );
                 if (strtolower($relationName) === strtolower($this->parent->getClassName())) {
                     $relationName = Str::plural($this->related->getClassName());
                 } else {

--- a/src/Coders/Model/Relations/HasOne.php
+++ b/src/Coders/Model/Relations/HasOne.php
@@ -38,4 +38,12 @@ class HasOne extends HasOneOrMany
     {
         return 'hasOne';
     }
+
+    /**
+     * @return string
+     */
+    public function returnType()
+    {
+        return \Illuminate\Database\Eloquent\Relations\HasOne::class;
+    }
 }

--- a/src/Coders/Model/Relations/HasOneOrManyStrategy.php
+++ b/src/Coders/Model/Relations/HasOneOrManyStrategy.php
@@ -60,4 +60,14 @@ class HasOneOrManyStrategy implements Relation
     {
         return $this->relation->body();
     }
+
+    /**
+     * @return string
+     */
+    public function returnType()
+    {
+        return get_class($this->relation) === HasMany::class ?
+            \Illuminate\Database\Eloquent\Relations\HasMany::class :
+            \Illuminate\Database\Eloquent\Relations\HasOne::class;
+    }
 }

--- a/src/Coders/Model/Relations/ReferenceFactory.php
+++ b/src/Coders/Model/Relations/ReferenceFactory.php
@@ -73,7 +73,7 @@ class ReferenceFactory
             return false;
         }
 
-        $pivot = str_replace($firstRecord, '', $pivot);
+        $pivot = preg_replace("!$firstRecord!", '', $pivot, 1);
 
         foreach ($this->getRelatedBlueprint()->relations() as $reference) {
             if ($reference == $this->getRelatedReference()) {

--- a/src/Coders/Model/Relations/RelationHelper.php
+++ b/src/Coders/Model/Relations/RelationHelper.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Reliese\Coders\Model\Relations;
+
+use Illuminate\Support\Str;
+
+/**
+ * General utility functions for dealing with relationships
+ */
+class RelationHelper
+{
+    /**
+     * Turns a column name like 'manager_id' into 'manager'; or 'lineManagerId' into 'lineManager'.
+     *
+     * @param bool $usesSnakeAttributes
+     * @param string $primaryKey
+     * @param string $foreignKey
+     * @return string
+     */
+    public static function stripSuffixFromForeignKey($usesSnakeAttributes, $primaryKey, $foreignKey)
+    {
+        if ($usesSnakeAttributes) {
+            $lowerPrimaryKey = strtolower($primaryKey);
+            return preg_replace('/(_)(' . $primaryKey . '|' . $lowerPrimaryKey . ')$/', '', $foreignKey);
+        } else {
+            $studlyPrimaryKey = Str::studly($primaryKey);
+            return preg_replace('/(' . $primaryKey . '|' . $studlyPrimaryKey . ')$/', '', $foreignKey);
+        }
+    }
+}

--- a/src/Database/Eloquent/WhoDidIt.php
+++ b/src/Database/Eloquent/WhoDidIt.php
@@ -40,7 +40,7 @@ class WhoDidIt
      */
     public function updating(Eloquent $model)
     {
-        $model->udpated_by = $this->doer();
+        $model->updated_by = $this->doer();
     }
 
     /**

--- a/src/Database/Eloquent/WhoDidIt.php
+++ b/src/Database/Eloquent/WhoDidIt.php
@@ -30,7 +30,7 @@ class WhoDidIt
     /**
      * @param \Illuminate\Database\Eloquent\Model $model
      */
-    public function creating($model)
+    public function creating(Eloquent $model)
     {
         $model->created_by = $this->doer();
     }

--- a/src/Database/Eloquent/WhoDidIt.php
+++ b/src/Database/Eloquent/WhoDidIt.php
@@ -28,19 +28,17 @@ class WhoDidIt
     }
 
     /**
-     * @param string $event
      * @param \Illuminate\Database\Eloquent\Model $model
      */
-    public function creating($event, Eloquent $model)
+    public function creating($model)
     {
         $model->created_by = $this->doer();
     }
 
     /**
-     * @param string $event
      * @param \Illuminate\Database\Eloquent\Model $model
      */
-    public function updating($event, Eloquent $model)
+    public function updating(Eloquent $model)
     {
         $model->udpated_by = $this->doer();
     }

--- a/src/Meta/MySql/Column.php
+++ b/src/Meta/MySql/Column.php
@@ -29,7 +29,7 @@ class Column implements \Reliese\Meta\Column
      * @var array
      */
     public static $mappings = [
-        'string' => ['varchar', 'text', 'string', 'char', 'enum', 'tinytext', 'mediumtext', 'longtext', 'longblob', 'mediumblob', 'tinyblob', 'blob'],
+        'string' => ['varchar', 'text', 'string', 'char', 'enum', 'set', 'tinytext', 'mediumtext', 'longtext', 'longblob', 'mediumblob', 'tinyblob', 'blob'],
         'date' => ['datetime', 'year', 'date', 'time', 'timestamp'],
         'int' => ['bigint', 'int', 'integer', 'tinyint', 'smallint', 'mediumint'],
         'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],

--- a/src/Meta/MySql/Column.php
+++ b/src/Meta/MySql/Column.php
@@ -30,7 +30,7 @@ class Column implements \Reliese\Meta\Column
      */
     public static $mappings = [
         'string' => ['varchar', 'text', 'string', 'char', 'enum', 'set', 'tinytext', 'mediumtext', 'longtext', 'longblob', 'mediumblob', 'tinyblob', 'blob'],
-        'date' => ['datetime', 'year', 'date', 'time', 'timestamp'],
+        'datetime' => ['datetime', 'year', 'date', 'time', 'timestamp'],
         'int' => ['bigint', 'int', 'integer', 'tinyint', 'smallint', 'mediumint'],
         'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
         'boolean' => ['bit']

--- a/src/Meta/MySql/Column.php
+++ b/src/Meta/MySql/Column.php
@@ -29,11 +29,11 @@ class Column implements \Reliese\Meta\Column
      * @var array
      */
     public static $mappings = [
-        'string' => ['varchar', 'text', 'string', 'char', 'enum', 'tinytext', 'mediumtext', 'longtext'],
+        'string' => ['varchar', 'text', 'string', 'char', 'enum', 'tinytext', 'mediumtext', 'longtext', 'longblob', 'mediumblob', 'tinyblob', 'blob'],
         'date' => ['datetime', 'year', 'date', 'time', 'timestamp'],
         'int' => ['bigint', 'int', 'integer', 'tinyint', 'smallint', 'mediumint'],
         'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
-        'boolean' => ['longblob', 'blob', 'bit'],
+        'boolean' => ['bit']
     ];
 
     /**

--- a/src/Meta/MySql/Schema.php
+++ b/src/Meta/MySql/Schema.php
@@ -270,8 +270,8 @@ class Schema implements \Reliese\Meta\Schema
      */
     public static function schemas(Connection $connection)
     {
-        $schemas = $connection->getDoctrineSchemaManager()->listDatabases();
-
+        $schemas = $connection->select('SELECT schema_name FROM information_schema.schemata');
+        $schemas = array_column($schemas, 'schema_name');
         return array_diff($schemas, [
             'information_schema',
             'sys',

--- a/src/Meta/Postgres/Column.php
+++ b/src/Meta/Postgres/Column.php
@@ -29,7 +29,7 @@ class Column implements \Reliese\Meta\Column
      */
     public static $mappings = [
       'string' => ['character varying', 'varchar', 'text', 'string', 'char', 'character','enum', 'tinytext', 'mediumtext', 'longtext', 'json'],
-      'date' => ['timestamp with time zone', 'timestamp without time zone', 'timestamptz', 'datetime', 'year', 'date', 'time', 'timestamp'],
+      'datetime' => ['timestamp with time zone', 'timestamp without time zone', 'timestamptz', 'datetime', 'year', 'date', 'time', 'timestamp'],
       'int' => ['int', 'integer', 'tinyint', 'smallint', 'mediumint', 'bigint', 'bigserial', 'serial', 'smallserial', 'tinyserial', 'serial4', 'serial8'],
       'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
       'boolean' => ['boolean', 'bool', 'bit'],

--- a/src/Meta/Postgres/Column.php
+++ b/src/Meta/Postgres/Column.php
@@ -194,7 +194,9 @@ class Column implements \Reliese\Meta\Column
     private function defaultIsNextVal(Fluent $attributes)
     {
         $value = $this->get('column_default', $this->get('generation_expression', null));
+        $isIdentity = $this->get('is_identity');
+        $identityGeneration =  $this->get('identity_generation');
 
-        return preg_match('/nextval\(/i', $value);
+        return preg_match('/nextval\(/i', $value) || ($isIdentity === 'YES' && $identityGeneration === 'BY DEFAULT');
     }
 }

--- a/src/Meta/Postgres/Column.php
+++ b/src/Meta/Postgres/Column.php
@@ -28,12 +28,12 @@ class Column implements \Reliese\Meta\Column
      * @todo check these
      */
     public static $mappings = [
-        'string' => ['varchar', 'text', 'string', 'char', 'enum', 'tinytext', 'mediumtext', 'longtext', 'json'],
-        'date' => ['datetime', 'year', 'date', 'time', 'timestamp'],
-        'int' => ['int', 'integer', 'tinyint', 'smallint', 'mediumint', 'bigint', 'bigserial', 'serial', 'smallserial', 'tinyserial', 'serial4', 'serial8'],
-        'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
-        'boolean' => ['boolean', 'bool', 'bit'],
-        'binary' => ['blob', 'longblob', 'jsonb'],
+      'string' => ['character varying', 'varchar', 'text', 'string', 'char', 'character','enum', 'tinytext', 'mediumtext', 'longtext', 'json'],
+      'date' => ['timestamp with time zone', 'timestamp without time zone', 'timestamptz', 'datetime', 'year', 'date', 'time', 'timestamp'],
+      'int' => ['int', 'integer', 'tinyint', 'smallint', 'mediumint', 'bigint', 'bigserial', 'serial', 'smallserial', 'tinyserial', 'serial4', 'serial8'],
+      'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
+      'boolean' => ['boolean', 'bool', 'bit'],
+      'binary' => ['blob', 'longblob', 'jsonb'],
     ];
 
     /**

--- a/src/Meta/Postgres/Column.php
+++ b/src/Meta/Postgres/Column.php
@@ -84,9 +84,8 @@ class Column implements \Reliese\Meta\Column
      */
     protected function parsePrecision($databaseType, Fluent $attributes)
     {
-        // Fix for str_replace() at line 88: Default to '0' if null
-        $precision = $this->get('numeric_precision', '0');
-        $precision = explode(',', str_replace("'", '', $precision));
+        $precision = $this->get('numeric_precision', ''); // Default to empty string instead of 'string'
+        $precision = explode(',', str_replace("'", '', $precision ?? '')); // Ensure $precision is string
 
         // Check whether it's an enum
         if ($databaseType == 'enum') {
@@ -193,11 +192,10 @@ class Column implements \Reliese\Meta\Column
      */
     private function defaultIsNextVal(Fluent $attributes)
     {
-        // Fix for preg_match() at line 200: Default to '' if null
-        $value = $this->get('column_default', $this->get('generation_expression', '')) ?? '';
+        $value = $this->get('column_default', $this->get('generation_expression', null));
         $isIdentity = $this->get('is_identity');
         $identityGeneration =  $this->get('identity_generation');
 
-        return preg_match('/nextval\(/i', $value) || ($isIdentity === 'YES' && $identityGeneration === 'BY DEFAULT');
+        return preg_match('/nextval\(/i', $value ?? '') || ($isIdentity === 'YES' && $identityGeneration === 'BY DEFAULT');
     }
 }

--- a/src/Meta/Postgres/Column.php
+++ b/src/Meta/Postgres/Column.php
@@ -20,7 +20,7 @@ class Column implements \Reliese\Meta\Column
      * @var array
      */
     protected $metas = [
-      'type', 'name', 'autoincrement', 'nullable', 'default', 'comment',
+        'type', 'name', 'autoincrement', 'nullable', 'default', 'comment',
     ];
 
     /**
@@ -28,12 +28,12 @@ class Column implements \Reliese\Meta\Column
      * @todo check these
      */
     public static $mappings = [
-      'string' => ['character varying', 'varchar', 'text', 'string', 'char', 'character','enum', 'tinytext', 'mediumtext', 'longtext', 'json'],
-      'datetime' => ['timestamp with time zone', 'timestamp without time zone', 'timestamptz', 'datetime', 'year', 'date', 'time', 'timestamp'],
-      'int' => ['int', 'integer', 'tinyint', 'smallint', 'mediumint', 'bigint', 'bigserial', 'serial', 'smallserial', 'tinyserial', 'serial4', 'serial8'],
-      'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
-      'boolean' => ['boolean', 'bool', 'bit'],
-      'binary' => ['blob', 'longblob', 'jsonb'],
+        'string' => ['character varying', 'varchar', 'text', 'string', 'char', 'character', 'enum', 'tinytext', 'mediumtext', 'longtext', 'json'],
+        'datetime' => ['timestamp with time zone', 'timestamp without time zone', 'timestamptz', 'datetime', 'year', 'date', 'time', 'timestamp'],
+        'int' => ['int', 'integer', 'tinyint', 'smallint', 'mediumint', 'bigint', 'bigserial', 'serial', 'smallserial', 'tinyserial', 'serial4', 'serial8'],
+        'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
+        'boolean' => ['boolean', 'bool', 'bit'],
+        'binary' => ['blob', 'longblob', 'jsonb'],
     ];
 
     /**
@@ -84,13 +84,13 @@ class Column implements \Reliese\Meta\Column
      */
     protected function parsePrecision($databaseType, Fluent $attributes)
     {
-        $precision = $this->get('numeric_precision', 'string');
+        // Fix for str_replace() at line 88: Default to '0' if null
+        $precision = $this->get('numeric_precision', '0');
         $precision = explode(',', str_replace("'", '', $precision));
 
         // Check whether it's an enum
         if ($databaseType == 'enum') {
             //$attributes['enum'] = $precision; //todo
-
             return;
         }
 
@@ -193,7 +193,8 @@ class Column implements \Reliese\Meta\Column
      */
     private function defaultIsNextVal(Fluent $attributes)
     {
-        $value = $this->get('column_default', $this->get('generation_expression', null));
+        // Fix for preg_match() at line 200: Default to '' if null
+        $value = $this->get('column_default', $this->get('generation_expression', '')) ?? '';
         $isIdentity = $this->get('is_identity');
         $identityGeneration =  $this->get('identity_generation');
 

--- a/src/Meta/Postgres/Schema.php
+++ b/src/Meta/Postgres/Schema.php
@@ -283,7 +283,8 @@ class Schema implements \Reliese\Meta\Schema
      */
     public static function schemas(Connection $connection)
     {
-        $schemas = $connection->getDoctrineSchemaManager()->listDatabases();
+        $schemas = $connection->select('SELECT datname FROM pg_database');
+        $schemas = array_column($schemas, 'datname');
 
         return array_diff($schemas, [
             'postgres',

--- a/src/Meta/SchemaManager.php
+++ b/src/Meta/SchemaManager.php
@@ -28,6 +28,7 @@ class SchemaManager implements IteratorAggregate
         SQLiteConnection::class => SqliteSchema::class,
         PostgresConnection::class => PostgresSchema::class,
         \Larapack\DoctrineSupport\Connections\MySqlConnection::class => MySqlSchema::class,
+        \Staudenmeir\LaravelCte\Connections\MySqlConnection::class => MySqlSchema::class,
     ];
 
     /**

--- a/src/Meta/SchemaManager.php
+++ b/src/Meta/SchemaManager.php
@@ -135,7 +135,7 @@ class SchemaManager implements IteratorAggregate
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->schemas);
     }

--- a/src/Meta/SchemaManager.php
+++ b/src/Meta/SchemaManager.php
@@ -10,6 +10,7 @@ namespace Reliese\Meta;
 use ArrayIterator;
 use RuntimeException;
 use IteratorAggregate;
+use Traversable; // Added this line
 use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\PostgresConnection;

--- a/src/Meta/Sqlite/Column.php
+++ b/src/Meta/Sqlite/Column.php
@@ -28,7 +28,7 @@ class Column implements \Reliese\Meta\Column
      */
     public static $mappings = [
         'string' => ['varchar', 'text', 'string', 'char', 'enum', 'tinytext', 'mediumtext', 'longtext'],
-        'date' => ['datetime', 'year', 'date', 'time', 'timestamp'],
+        'datetime' => ['datetime', 'year', 'date', 'time', 'timestamp'],
         'int' => ['bigint', 'int', 'integer', 'tinyint', 'smallint', 'mediumint'],
         'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
         'boolean' => ['longblob', 'blob', 'bit'],

--- a/src/Meta/Sqlite/Schema.php
+++ b/src/Meta/Sqlite/Schema.php
@@ -144,7 +144,7 @@ class Schema implements \Reliese\Meta\Schema
         $key = [
             'name' => 'primary',
             'index' => '',
-            'columns' => $indexes['primary']->getColumns(),
+            'columns' => optional($indexes['primary']??null)->getColumns()?:[],
         ];
 
         $blueprint->withPrimaryKey(new Fluent($key));

--- a/src/Support/Classify.php
+++ b/src/Support/Classify.php
@@ -67,8 +67,10 @@ class Classify
     public function method($name, $body, $options = [])
     {
         $visibility = Arr::get($options, 'visibility', 'public');
+        $returnType = Arr::get($options, 'returnType', null);
+        $formattedReturnType = $returnType ? ': '.$returnType : '';
 
-        return "\n\t$visibility function $name()\n\t{\n\t\t$body\n\t}\n";
+        return "\n\t$visibility function $name()$formattedReturnType\n\t{\n\t\t$body\n\t}\n";
     }
 
     public function mixin($class)

--- a/tests/Coders/Model/Relations/BelongsToTest.php
+++ b/tests/Coders/Model/Relations/BelongsToTest.php
@@ -11,11 +11,11 @@ class BelongsToTest extends TestCase
     {
         // usesSnakeAttributes, primaryKey, foreignKey, expected
         return [
-            // columns use snake_case
+            // columns use camelCase
             [false, 'id', 'lineManagerId', 'lineManager'],
             [false, 'Id', 'lineManagerId', 'lineManager'],
             [false, 'ID', 'lineManagerID', 'lineManager'],
-            // columns use camelCase
+            // columns use snake_case
             [true, 'id', 'line_manager_id', 'line_manager'],
             [true, 'ID', 'line_manager_id', 'line_manager'],
             // foreign keys without primary key suffix
@@ -36,10 +36,9 @@ class BelongsToTest extends TestCase
     {
         $relation = Mockery::mock(Fluent::class)->makePartial();
 
-        $modelMock = Mockery::mock(Model::class);
-        $relatedModel = $modelMock->makePartial();
+        $relatedModel = Mockery::mock(Model::class)->makePartial();
 
-        $subject = $modelMock->makePartial();
+        $subject = Mockery::mock(Model::class)->makePartial();
         $subject->shouldReceive('getRelationNameStrategy')->andReturn('foreign_key');
         $subject->shouldReceive('usesSnakeAttributes')->andReturn($usesSnakeAttributes);
 
@@ -76,11 +75,10 @@ class BelongsToTest extends TestCase
     {
         $relation = Mockery::mock(Fluent::class)->makePartial();
 
-        $modelMock = Mockery::mock(Model::class);
-        $relatedModel = $modelMock->makePartial();
+        $relatedModel = Mockery::mock(Model::class)->makePartial();
         $relatedModel->shouldReceive('getClassName')->andReturn($relatedClassName);
 
-        $subject = $modelMock->makePartial();
+        $subject = Mockery::mock(Model::class)->makePartial();
         $subject->shouldReceive('getRelationNameStrategy')->andReturn('related');
         $subject->shouldReceive('usesSnakeAttributes')->andReturn($usesSnakeAttributes);
 

--- a/tests/Coders/Model/Relations/BelongsToTest.php
+++ b/tests/Coders/Model/Relations/BelongsToTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Support\Fluent;
+use PHPUnit\Framework\TestCase;
+use Reliese\Coders\Model\Relations\BelongsTo;
+
+class BelongsToTest extends TestCase
+{
+    public function provideForeignKeyStrategyPermutations()
+    {
+        // usesSnakeAttributes, primaryKey, foreignKey, expected
+        return [
+            // columns use snake_case
+            [false, 'id', 'lineManagerId', 'lineManager'],
+            [false, 'Id', 'lineManagerId', 'lineManager'],
+            [false, 'ID', 'lineManagerID', 'lineManager'],
+            // columns use camelCase
+            [true, 'id', 'line_manager_id', 'line_manager'],
+            [true, 'ID', 'line_manager_id', 'line_manager'],
+            // foreign keys without primary key suffix
+            [false, 'id', 'lineManager', 'lineManager'],
+            [true, 'id', 'line_manager', 'line_manager'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideForeignKeyStrategyPermutations
+     *
+     * @param bool $usesSnakeAttributes
+     * @param string $primaryKey
+     * @param string $foreignKey
+     * @param string $expected
+     */
+    public function testNameUsingForeignKeyStrategy($usesSnakeAttributes, $primaryKey, $foreignKey, $expected)
+    {
+        $relation = Mockery::mock(Fluent::class)->makePartial();
+
+        $modelMock = Mockery::mock(\Reliese\Coders\Model\Model::class);
+        $relatedModel = $modelMock->makePartial();
+
+        $subject = $modelMock->makePartial();
+        $subject->shouldReceive('usesSnakeAttributes')->andReturn($usesSnakeAttributes);
+
+        /** @var BelongsTo|\Mockery\Mock $relationship */
+        $relationship = Mockery::mock(BelongsTo::class, [$relation, $subject, $relatedModel])->makePartial();
+        $relationship->shouldAllowMockingProtectedMethods();
+        $relationship->shouldReceive('otherKey')->andReturn($primaryKey);
+        $relationship->shouldReceive('foreignKey')->andReturn($foreignKey);
+
+        $this->assertEquals(
+            $expected,
+            $relationship->name(),
+            json_encode(compact('usesSnakeAttributes', 'primaryKey', 'foreignKey'))
+        );
+    }
+}

--- a/tests/Coders/Model/Relations/HasManyTest.php
+++ b/tests/Coders/Model/Relations/HasManyTest.php
@@ -13,22 +13,23 @@ class HasManyTest extends TestCase
         // usesSnakeAttributes, subjectName, relationName, primaryKey, foreignKey, expected
         return [
             // camelCase
-            [false, 'Person', 'PublishedBook', 'id', 'authorId', 'publishedBooksWhereAuthor'],
-            [false, 'Person', 'PublishedBook', 'ID', 'authorID', 'publishedBooksWhereAuthor'],
-            [false, 'Person', 'PublishedBook', 'id', 'personId', 'publishedBooks'],
-            [false, 'Person', 'PublishedBook', 'ID', 'personID', 'publishedBooks'],
+            [false, 'StaffMember', 'BlogPost', 'id', 'authorId', 'blogPostsWhereAuthor'],
+            [false, 'StaffMember', 'BlogPost', 'ID', 'authorID', 'blogPostsWhereAuthor'],
+            [false, 'StaffMember', 'BlogPost', 'id', 'staffMemberId', 'blogPosts'],
+            [false, 'StaffMember', 'BlogPost', 'ID', 'staffMemberID', 'blogPosts'],
             // snake_case
-            [true, 'Person', 'PublishedBook', 'id', 'author_id', 'published_books_where_author'],
-            [true, 'Person', 'PublishedBook', 'id', 'person_id', 'published_books'],
-            [true, 'Person', 'PublishedBook', 'ID', 'author_id', 'published_books_where_author'],
-            [true, 'Person', 'PublishedBook', 'ID', 'person_id', 'published_books'],
+            [true, 'StaffMember', 'BlogPost', 'id', 'author_id', 'blog_posts_where_author'],
+            [true, 'StaffMember', 'BlogPost', 'id', 'staff_member_id', 'blog_posts'],
+            [true, 'StaffMember', 'BlogPost', 'ID', 'author_id', 'blog_posts_where_author'],
+            [true, 'StaffMember', 'BlogPost', 'ID', 'staff_member_id', 'blog_posts'],
             // no suffix
-            [false, 'Person', 'PublishedBook', 'id', 'author', 'publishedBooksWhereAuthor'],
-            [false, 'Person', 'PublishedBook', 'id', 'person', 'publishedBooks'],
-            [true, 'Person', 'PublishedBook', 'id', 'author', 'published_books_where_author'],
-            [true, 'Person', 'PublishedBook', 'id', 'person', 'published_books'],
+            [false, 'StaffMember', 'BlogPost', 'id', 'author', 'blogPostsWhereAuthor'],
+            [false, 'StaffMember', 'BlogPost', 'id', 'staff_member', 'blogPosts'],
+            [true, 'StaffMember', 'BlogPost', 'id', 'author', 'blog_posts_where_author'],
+            [true, 'StaffMember', 'BlogPost', 'id', 'staff_member', 'blog_posts'],
             // same table reference
-            [false, 'Person', 'Person', 'id', 'lineManagerId', 'peopleWhereLineManager'],
+            [false, 'StaffMember', 'StaffMember', 'id', 'staffMemberId', 'staffMembers'],
+            [false, 'StaffMember', 'StaffMember', 'id', 'lineManagerId', 'staffMembersWhereLineManager'],
         ];
     }
 
@@ -71,10 +72,10 @@ class HasManyTest extends TestCase
     {
         // usesSnakeAttributes, subjectName, relatedName, expected
         return [
-            [false, 'Person', 'PublishedBook', 'publishedBooks'],
-            [true, 'Person', 'PublishedBook', 'published_books'],
+            [false, 'StaffMember', 'BlogPost', 'blogPosts'],
+            [true, 'StaffMember', 'BlogPost', 'blog_posts'],
             // Same table reference
-            [false, 'Person', 'Person', 'people']
+            [false, 'StaffMember', 'StaffMember', 'staffMembers']
         ];
     }
 

--- a/tests/Coders/Model/Relations/HasManyTest.php
+++ b/tests/Coders/Model/Relations/HasManyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Support\Fluent;
+use PHPUnit\Framework\TestCase;
+use Reliese\Coders\Model\Model;
+use Reliese\Coders\Model\Relations\BelongsTo;
+use Reliese\Coders\Model\Relations\HasMany;
+
+class HasManyTest extends TestCase
+{
+    public function provideForeignKeyStrategyPermutations()
+    {
+        // usesSnakeAttributes, subjectName, relationName, primaryKey, foreignKey, expected
+        return [
+            // camelCase
+            [false, 'Person', 'Book', 'id', 'authorId', 'booksWhereAuthor'],
+            [false, 'Person', 'Book', 'ID', 'authorID', 'booksWhereAuthor'],
+            [false, 'Person', 'Book', 'id', 'personId', 'books'],
+            [false, 'Person', 'Book', 'ID', 'personID', 'books'],
+            // snake_case
+            [true, 'Person', 'Book', 'id', 'author_id', 'books_where_author'],
+            [true, 'Person', 'Book', 'id', 'person_id', 'books'],
+            [true, 'Person', 'Book', 'ID', 'author_id', 'books_where_author'],
+            [true, 'Person', 'Book', 'ID', 'person_id', 'books'],
+            // no suffix
+            [false, 'Person', 'Book', 'id', 'author', 'booksWhereAuthor'],
+            [false, 'Person', 'Book', 'id', 'person', 'books'],
+            [true, 'Person', 'Book', 'id', 'author', 'books_where_author'],
+            [true, 'Person', 'Book', 'id', 'person', 'books'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideForeignKeyStrategyPermutations
+     *
+     * @param bool $usesSnakeAttributes
+     * @param string $subjectName
+     * @param string $relationName
+     * @param string $primaryKey
+     * @param string $foreignKey
+     * @param string $expected
+     */
+    public function testNameUsingForeignKeyStrategy($usesSnakeAttributes, $subjectName, $relationName, $primaryKey, $foreignKey, $expected)
+    {
+        $relation = Mockery::mock(Fluent::class)->makePartial();
+
+        $relatedModel = Mockery::mock(Model::class)->makePartial();
+        $relatedModel->shouldReceive('getClassName')->andReturn($relationName);
+
+        $subject = Mockery::mock(Model::class)->makePartial();
+        $subject->shouldReceive('getRelationNameStrategy')->andReturn('foreign_key');
+        $subject->shouldReceive('usesSnakeAttributes')->andReturn($usesSnakeAttributes);
+        $subject->shouldReceive('getClassName')->andReturn($subjectName);
+
+        /** @var BelongsTo|\Mockery\Mock $relationship */
+        $relationship = Mockery::mock(HasMany::class, [$relation, $subject, $relatedModel])->makePartial();
+        $relationship->shouldAllowMockingProtectedMethods();
+        $relationship->shouldReceive('localKey')->andReturn($primaryKey);
+        $relationship->shouldReceive('foreignKey')->andReturn($foreignKey);
+
+        $this->assertEquals(
+            $expected,
+            $relationship->name(),
+            json_encode(compact('usesSnakeAttributes', 'subjectName', 'relationName', 'primaryKey', 'foreignKey'))
+        );
+    }
+}

--- a/tests/Coders/Model/Relations/RelationHelperTest.php
+++ b/tests/Coders/Model/Relations/RelationHelperTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Reliese\Coders\Model\Relations\RelationHelper;
+
+class RelationHelperTest extends TestCase
+{
+    public function provideKeys()
+    {
+        // usesSnakeAttributes, primaryKey, foreignKey, expected
+        return [
+            // camelCase
+            [false, 'id', 'lineManagerId', 'lineManager'],
+            [false, 'ID', 'lineManagerID', 'lineManager'],
+            // snake_case
+            [true, 'id', 'line_manager_id', 'line_manager'],
+            [true, 'ID', 'line_manager_id', 'line_manager'],
+            // no suffix
+            [false, 'id', 'lineManager', 'lineManager'],
+            [true, 'id', 'line_manager', 'line_manager'],
+            // columns that contain the letters of the primary key as part of their name
+            [false, 'id', 'holiday', 'holiday'],
+            [true, 'id', 'something_identifier_id', 'something_identifier']
+        ];
+    }
+
+    /**
+     * @dataProvider provideKeys
+     *
+     * @param bool $usesSnakeAttributes
+     * @param string $primaryKey
+     * @param string $foreignKey
+     * @param string $expected
+     */
+    public function testNameUsingForeignKeyStrategy($usesSnakeAttributes, $primaryKey, $foreignKey, $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            RelationHelper::stripSuffixFromForeignKey($usesSnakeAttributes, $primaryKey, $foreignKey),
+            json_encode(compact('usesSnakeAttributes', 'primaryKey', 'foreignKey'))
+        );
+    }
+}


### PR DESCRIPTION
Fix PHP 8.4 compatibility: 
- Handles null in preg_match/str_replace in Postgres/Column.php, 
- Adds Traversable return type to ModelManager::getIterator and SchemaManager::getIterator with use Traversable