### PR TITLE
Fix and run tests automatically using github action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,8 @@ jobs:
               php: 7.4
             - laravel: "^9.0"
               php: 7.3
+            - php: 8.0
+              dependency-version: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,12 +12,14 @@ jobs:
         php: [8.0, 7.4, 7.3]
         laravel: ["^9.0", "^8.0"]
         dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - php: 8.0
+            dependency-version: prefer-stable
         exclude:
             - laravel: "^9.0"
               php: 7.4
             - laravel: "^9.0"
               php: 7.3
-            - laravel: "^9.0"
             - php: 8.0
               dependency-version: prefer-lowest
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,39 @@
+name: "Run Tests - Current"
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.0, 7.4, 7.3]
+        laravel: ["^9.0", "^8.0"]
+        dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+            - laravel: "^9.0"
+              php: 7.4
+              php: 7.3
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: curl, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, iconv
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,15 +12,12 @@ jobs:
         php: [8.0, 7.4, 7.3]
         laravel: ["^9.0", "^8.0"]
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - php: 8.0
-            dependency-version: prefer-stable
         exclude:
             - laravel: "^9.0"
               php: 7.4
             - laravel: "^9.0"
               php: 7.3
-            - php: 8.0
+            - laravel: "^9.0"
               dependency-version: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,7 @@ jobs:
               php: 7.4
             - laravel: "^9.0"
               php: 7.3
+            - laravel: "^9.0"
             - php: 8.0
               dependency-version: prefer-lowest
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,7 @@ jobs:
         exclude:
             - laravel: "^9.0"
               php: 7.4
+            - laravel: "^9.0"
               php: 7.3
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -352,6 +352,7 @@ class Model
             case 'collection':
                 $type = '\Illuminate\Support\Collection';
                 break;
+            case 'date':
             case 'datetime':
                 $type = '\Carbon\Carbon';
                 break;


### PR DESCRIPTION
1. fix broken test:
    ```
    - 1) ModelTest::testPhpTypeHint with data set "Non-nullable date" ('date', false, '\Carbon\Carbon')
    - 2) ModelTest::testPhpTypeHint with data set "Nullable date" ('date', true, '\Carbon\Carbon|null')
    ```
2. add `.github/workflows/run-tests.yml` run atomatically matrix tests (PHP 7.3, 7.4, 8.0 & Laravel 8.0, 9.0)