### PR TITLE
feat: Implement casting column types using column comments

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -269,6 +269,25 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Comment Casts
+        |--------------------------------------------------------------------------
+        |
+        | As an alternative to the column casts, you may want to specify casts
+        | using comments in your database table columns.
+        |
+        | You may define strings that should be contained in comments,
+        | which will be cast using the value assigned. Please note that
+        | these are case sensitive. We have defined some fields for you.
+        | Feel free to modify them to fit your needs.
+        |
+        */
+
+        'comment_casts' => [
+            '{{json}}' => 'json',
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
         | Excluded Tables
         |--------------------------------------------------------------------------
         |

--- a/src/Coders/Model/Model.php
+++ b/src/Coders/Model/Model.php
@@ -274,6 +274,13 @@ class Model
             }
         }
 
+        foreach ($this->config('comment_casts', []) as $needle => $casting) {
+            if (Str::contains($column->comment, $needle)) {
+                $this->casts[$propertyName] = $cast = $casting;
+                break;
+            }
+        }
+
         if ($this->isHidden($column->name)) {
             $this->hidden[] = $propertyName;
         }


### PR DESCRIPTION
Added a simple way to cast column data types using column comments, simply because I don't like adding things like `_json` to column names.