### PR TITLE
fix: PostgreSQL improvements - \c command, jsonb mapping, partition tables, schema loading

### DIFF
--- a/config/models.php
+++ b/config/models.php
@@ -289,6 +289,21 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Exclude Partition Children (PostgreSQL)
+        |--------------------------------------------------------------------------
+        |
+        | When using PostgreSQL table partitioning, child partition tables
+        | (e.g. users_p000, users_p001) are automatically created. These
+        | tables share the same schema as the parent table and should not
+        | generate separate models. Enable this option to automatically
+        | exclude partition child tables by querying pg_inherits.
+        |
+        */
+
+        'exclude_partition_children' => false,
+
+        /*
+        |--------------------------------------------------------------------------
         | Specified Tables
         |--------------------------------------------------------------------------
         |

--- a/src/Meta/Postgres/Column.php
+++ b/src/Meta/Postgres/Column.php
@@ -28,12 +28,13 @@ class Column implements \Reliese\Meta\Column
      * @todo check these
      */
     public static $mappings = [
-      'string' => ['character varying', 'varchar', 'text', 'string', 'char', 'character','enum', 'tinytext', 'mediumtext', 'longtext', 'json'],
+      'string' => ['character varying', 'varchar', 'text', 'string', 'char', 'character','enum', 'tinytext', 'mediumtext', 'longtext'],
+      'json' => ['json', 'jsonb'],
       'datetime' => ['timestamp with time zone', 'timestamp without time zone', 'timestamptz', 'datetime', 'year', 'date', 'time', 'timestamp'],
       'int' => ['int', 'integer', 'tinyint', 'smallint', 'mediumint', 'bigint', 'bigserial', 'serial', 'smallserial', 'tinyserial', 'serial4', 'serial8'],
       'float' => ['float', 'decimal', 'numeric', 'dec', 'fixed', 'double', 'real', 'double precision'],
       'boolean' => ['boolean', 'bool', 'bit'],
-      'binary' => ['blob', 'longblob', 'jsonb'],
+      'binary' => ['blob', 'longblob'],
     ];
 
     /**

--- a/src/Meta/Postgres/Schema.php
+++ b/src/Meta/Postgres/Schema.php
@@ -71,9 +71,6 @@ class Schema implements \Reliese\Meta\Schema
      */
     protected function load()
     {
-        // Note that "schema" refers to the database name,
-        // not a pgsql schema.
-        $this->connection->raw('\c '.$this->wrap($this->schema));
         $tables = $this->fetchTables($this->schema);
         foreach ($tables as $table) {
             $blueprint = new Blueprint($this->connection->getName(), $this->schema, $table);
@@ -91,9 +88,22 @@ class Schema implements \Reliese\Meta\Schema
      */
     protected function fetchTables()
     {
-        $rows = $this->arraify($this->connection->select(
-            "SELECT * FROM pg_tables where schemaname='$this->schema_database'"
-        ));
+        $excludePartitions = Config::get('models.*.exclude_partition_children', false);
+
+        if ($excludePartitions) {
+            $rows = $this->arraify($this->connection->select(
+                "SELECT t.tablename FROM pg_tables t
+                 JOIN pg_class c ON c.relname = t.tablename
+                     AND c.relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = '$this->schema_database')
+                 WHERE t.schemaname = '$this->schema_database'
+                     AND NOT EXISTS (SELECT 1 FROM pg_inherits i WHERE i.inhrelid = c.oid)"
+            ));
+        } else {
+            $rows = $this->arraify($this->connection->select(
+                "SELECT * FROM pg_tables where schemaname='$this->schema_database'"
+            ));
+        }
+
         $names = array_column($rows, 'tablename');
 
         return Arr::flatten($names);

--- a/src/Meta/SchemaManager.php
+++ b/src/Meta/SchemaManager.php
@@ -56,18 +56,15 @@ class SchemaManager implements IteratorAggregate
     }
 
     /**
-     * Load all schemas from this connection.
+     * Validate mapping exists. Schemas are lazy-loaded by make() on demand
+     * to avoid eagerly loading all databases (which causes unnecessary queries
+     * and memory usage, especially in PostgreSQL where each schema loads all
+     * table metadata on construction).
      */
     public function boot()
     {
         if (! $this->hasMapping()) {
             throw new RuntimeException("There is no Schema Mapper registered for [{$this->type()}] connection.");
-        }
-
-        $schemas = forward_static_call([$this->getMapper(), 'schemas'], $this->connection);
-
-        foreach ($schemas as $schema) {
-            $this->make($schema);
         }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes several PostgreSQL-related issues:

### 1. Remove `\c` psql meta-command (Critical)
- `\c` is a **psql interactive client command**, not valid SQL
- Executing it via PDO causes the connection to **hang indefinitely**
- PostgreSQL connections are already bound to a specific database, so database switching is unnecessary
- This was likely carried over from the MySQL adapter where `USE database` is valid SQL

### 2. Fix `jsonb` type mapping
- Previously `jsonb` was mapped to `binary`, which is incorrect
- `jsonb` is PostgreSQL's binary JSON type and should be mapped to `json` for proper Laravel casting
- Also moved `json` from `string` mapping to a dedicated `json` mapping for consistency

### 3. Add `exclude_partition_children` config option
- PostgreSQL table partitioning creates child tables (e.g., `users_p000`, `users_p001`) that share the parent's schema
- With many partitions (e.g., 8 types × 128 partitions = 1024 tables), loading all table metadata causes **excessive memory usage and OOM kills**
- Added a new config option `exclude_partition_children` (default: `false`) that uses `pg_inherits` to filter out partition child tables
- This is opt-in to maintain backward compatibility

### 4. Lazy-load schemas in SchemaManager
- Previously `boot()` eagerly loaded **all databases** from `pg_database` and created Schema objects for each
- In PostgreSQL, connections are database-specific, so querying other databases' metadata from the current connection returns duplicate data
- Changed to lazy-loading: schemas are created on demand when `make()` is called
- This avoids loading the same tables N times (once per database on the server)

## Test plan
- [x] Tested with PostgreSQL 18.1, PHP 8.5
- [x] Verified `code:models -t <table>` completes successfully
- [x] Verified `code:models` (all tables) completes successfully
- [x] Verified `jsonb` columns are properly mapped to `json` type
- [x] Verified `exclude_partition_children` config filters partition tables correctly