### PR TITLE
Fixing issue with resolving indexes for Postgres.

### DIFF
--- a/src/Meta/Postgres/Schema.php
+++ b/src/Meta/Postgres/Schema.php
@@ -200,7 +200,7 @@ class Schema implements \Reliese\Meta\Schema
     protected function fillIndexes($indexes, Blueprint $blueprint)
     {
         foreach ($indexes as $row) {
-            $pattern = '/\s*(UNIQUE)?\s*(KEY|INDEX)\s+(\w+)\s+\(([^\)]+)\)/mi';
+            $pattern = '/\s*(UNIQUE)?\s*(KEY|INDEX)\s+(\w+)\s+.*?\(([^\)]+)\)/mi';
             if (preg_match($pattern, $row['indexdef'], $setup) == false) {
                 continue;
             }


### PR DESCRIPTION
Not sure if this is happening on the MySQL as well but noticed when using this with Postgres that almost all generated relationships were `HasMany` or `BelongsToMany` even if there were unique keys or indexes.

Best I could tell the regex for matching the index definitions was not matching a string like:
```sql
CREATE UNIQUE INDEX addons_product_id_unique ON public.addons USING btree (product_id)
```

It seemed like the regex was expecting something like:
```sql
CREATE UNIQUE INDEX addons_product_id_unique (product_id)
```
And maybe that's a MySQL syntax? Not sure. But changing the regex here seemed to correctly detect unique indexes and then bubbling up to the generator when determining if a relationship is a HasOne/BelongsTo or HasMany/BelongsToMany.